### PR TITLE
[FEAT] 채팅방 조회 구현

### DIFF
--- a/omocha-client/build.gradle
+++ b/omocha-client/build.gradle
@@ -20,6 +20,8 @@ dependencies {
     // java 8 date module added
     implementation 'com.fasterxml.jackson.datatype:jackson-datatype-jsr310:2.15.2'
 
+    // websocket
+    implementation 'org.springframework.boot:spring-boot-starter-websocket'
 
     // lombok
     annotationProcessor 'org.projectlombok:lombok'

--- a/omocha-client/src/main/java/org/auction/client/chat/application/ChatRoomService.java
+++ b/omocha-client/src/main/java/org/auction/client/chat/application/ChatRoomService.java
@@ -53,8 +53,7 @@ public class ChatRoomService {
 			throw new NoBidsException(NO_BIDS_FOUND);
 		}
 
-		// TODO : 지금은 경매 제목으로 존재하는 검증이 있으면 채팅방이 생성 안되게 검증을 했는데 변경을 해야함
-		if (roomRepository.existsByRoomName(auctionEntity.getTitle())) {
+		if (roomRepository.existsByAuctionId(auctionId)) {
 			throw new ChatRoomAlreadyExistsException(CHATROOM_ALREADY_EXISTS);
 		}
 
@@ -63,6 +62,7 @@ public class ChatRoomService {
 			.nowPrice(nowPrice)
 			.buyer(buyer)
 			.seller(seller)
+			.auctionId(auctionId)
 			.build();
 		roomRepository.save(chatRoom);
 

--- a/omocha-client/src/main/java/org/auction/client/chat/application/ChatRoomService.java
+++ b/omocha-client/src/main/java/org/auction/client/chat/application/ChatRoomService.java
@@ -42,7 +42,7 @@ public class ChatRoomService {
 
 		MemberEntity seller = auctionEntity.getMemberEntity();
 
-		if (seller.equals(buyer)) {
+		if (seller.getMemberId() == buyer.getMemberId()) {
 			throw new SellerIsBuyerException(SELLER_IS_BUYER);
 		}
 

--- a/omocha-client/src/main/java/org/auction/client/chat/application/ChatRoomService.java
+++ b/omocha-client/src/main/java/org/auction/client/chat/application/ChatRoomService.java
@@ -1,0 +1,86 @@
+package org.auction.client.chat.application;
+
+import static org.auction.client.common.code.AuctionCode.*;
+import static org.auction.client.common.code.BidCode.*;
+import static org.auction.client.common.code.ChatCode.*;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+import org.auction.client.bid.application.BidService;
+import org.auction.client.chat.interfaces.response.ChatRoomListResponse;
+import org.auction.client.chat.interfaces.response.CreateChatRoomResponse;
+import org.auction.client.exception.auction.AuctionNotFoundException;
+import org.auction.client.exception.bid.NoBidsException;
+import org.auction.client.exception.chat.ChatRoomAlreadyExistsException;
+import org.auction.client.exception.chat.SellerIsBuyerException;
+import org.auction.domain.auction.domain.entity.AuctionEntity;
+import org.auction.domain.auction.infrastructure.AuctionRepository;
+import org.auction.domain.chat.domain.entity.ChatRoomEntity;
+import org.auction.domain.chat.infrastructure.ChatRoomRepository;
+import org.auction.domain.member.domain.entity.MemberEntity;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class ChatRoomService {
+
+	private final ChatRoomRepository roomRepository;
+	private final AuctionRepository auctionRepository;
+	private final BidService bidService;
+
+	@Transactional
+	public CreateChatRoomResponse addChatRoom(
+		MemberEntity buyer,
+		Long auctionId
+	) {
+		AuctionEntity auctionEntity = auctionRepository.findById(auctionId)
+			.orElseThrow(() -> new AuctionNotFoundException(AUCTION_NOT_FOUND));
+
+		MemberEntity seller = auctionEntity.getMemberEntity();
+
+		if (seller.equals(buyer)) {
+			throw new SellerIsBuyerException(SELLER_IS_BUYER);
+		}
+
+		// TODO : 낙찰에서 가격을 조회하는 걸로 변경해야함, 가격이 없으면 예외를 터트려 줘야함
+		Long nowPrice = bidService.getCurrentHighestBidPrice(auctionEntity);
+
+		if (nowPrice == null) {
+			throw new NoBidsException(NO_BIDS_FOUND);
+		}
+
+		// TODO : 지금은 경매 제목으로 존재하는 검증이 있으면 채팅방이 생성 안되게 검증을 했는데 변경을 해야함
+		if (roomRepository.existsByRoomName(auctionEntity.getTitle())) {
+			throw new ChatRoomAlreadyExistsException(CHATROOM_ALREADY_EXISTS);
+		}
+
+		ChatRoomEntity chatRoom = ChatRoomEntity.builder()
+			.roomName(auctionEntity.getTitle())
+			.nowPrice(nowPrice)
+			.buyer(buyer)
+			.seller(seller)
+			.build();
+		roomRepository.save(chatRoom);
+
+		return CreateChatRoomResponse.toDto(chatRoom);
+	}
+
+	// TODO : pagination 으로 추후에 변경할거임
+	@Transactional(readOnly = true)
+	public ChatRoomListResponse findMyChatRooms(MemberEntity memberEntity) {
+		List<ChatRoomEntity> chatRooms = roomRepository.findByBuyerOrSeller(memberEntity, memberEntity);
+
+		List<CreateChatRoomResponse> chatRoomResponses = chatRooms.stream()
+			.map(CreateChatRoomResponse::toDto)
+			.collect(Collectors.toList());
+
+		return new ChatRoomListResponse(chatRoomResponses);
+	}
+
+	// TODO : 채팅방 상세 내용 불러오는 로직 필요
+
+}

--- a/omocha-client/src/main/java/org/auction/client/chat/interfaces/ChatRoomApi.java
+++ b/omocha-client/src/main/java/org/auction/client/chat/interfaces/ChatRoomApi.java
@@ -1,0 +1,73 @@
+package org.auction.client.chat.interfaces;
+
+import org.auction.client.chat.interfaces.response.ChatRoomListResponse;
+import org.auction.client.chat.interfaces.response.CreateChatRoomResponse;
+import org.auction.client.common.dto.ResultDto;
+import org.auction.client.jwt.UserPrincipal;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.PathVariable;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.enums.ParameterIn;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+
+public interface ChatRoomApi {
+
+	@Operation(
+		summary = "채팅방 생성", description = "특정 경매에 대한 채팅방을 생성합니다."
+	)
+	@ApiResponses(value = {
+		@ApiResponse(responseCode = "201", description = "채팅방이 성공적으로 생성되었습니다.",
+			content = @Content(mediaType = "application/json", schema = @Schema(implementation = ResultDto.class))),
+		@ApiResponse(responseCode = "400", description = "잘못된 요청입니다.",
+			content = @Content(mediaType = "application/json", schema = @Schema(implementation = ResultDto.class))),
+		@ApiResponse(responseCode = "401", description = "인증되지 않은 사용자입니다.",
+			content = @Content(mediaType = "application/json", schema = @Schema(implementation = ResultDto.class))),
+		@ApiResponse(responseCode = "409", description = "이미 존재하는 채팅방입니다.",
+			content = @Content(mediaType = "application/json", schema = @Schema(implementation = ResultDto.class))),
+		@ApiResponse(responseCode = "500", description = "서버 오류가 발생했습니다.",
+			content = @Content(mediaType = "application/json", schema = @Schema(implementation = ResultDto.class)))
+	})
+	ResponseEntity<ResultDto<CreateChatRoomResponse>> chatRoomSave(
+		@Parameter(
+			description = "경매 ID",
+			required = true,
+			example = "12",
+			in = ParameterIn.PATH
+		)
+		@PathVariable Long auctionId,
+
+		@Parameter(
+			description = "인증된 사용자 정보",
+			required = true,
+			in = ParameterIn.COOKIE
+		)
+		@AuthenticationPrincipal UserPrincipal userPrincipal
+	);
+
+	@Operation(
+		summary = "채팅방 목록 조회",
+		description = "인증된 사용자가 참여한 모든 채팅방 목록을 조회합니다."
+	)
+	@ApiResponses(value = {
+		@ApiResponse(responseCode = "200", description = "채팅방 목록 조회 성공",
+			content = @Content(mediaType = "application/json", schema = @Schema(implementation = ResultDto.class))),
+		@ApiResponse(responseCode = "401", description = "인증되지 않은 사용자입니다.",
+			content = @Content(mediaType = "application/json", schema = @Schema(implementation = ResultDto.class))),
+		@ApiResponse(responseCode = "500", description = "서버 오류가 발생했습니다.",
+			content = @Content(mediaType = "application/json", schema = @Schema(implementation = ResultDto.class)))
+	})
+	ResponseEntity<ResultDto<ChatRoomListResponse>> findChatRooms(
+		@Parameter(
+			description = "인증된 사용자 정보",
+			required = true,
+			in = ParameterIn.HEADER
+		)
+		@AuthenticationPrincipal UserPrincipal userPrincipal
+	);
+}

--- a/omocha-client/src/main/java/org/auction/client/chat/interfaces/ChatRoomController.java
+++ b/omocha-client/src/main/java/org/auction/client/chat/interfaces/ChatRoomController.java
@@ -1,0 +1,75 @@
+package org.auction.client.chat.interfaces;
+
+import static org.auction.client.common.code.ChatCode.*;
+
+import org.auction.client.chat.application.ChatRoomService;
+import org.auction.client.chat.interfaces.response.ChatRoomListResponse;
+import org.auction.client.chat.interfaces.response.CreateChatRoomResponse;
+import org.auction.client.common.dto.ResultDto;
+import org.auction.client.jwt.UserPrincipal;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/chatroom")
+public class ChatRoomController {
+
+	private final ChatRoomService chatRoomService;
+
+	// EXPLAIN : 채팅방 생성
+	// TODO : 낙찰이 되면 바로 채팅방 생성 로직으로 변경
+	@PostMapping("/{auctionId}")
+	public ResponseEntity<ResultDto<CreateChatRoomResponse>> chatRoomSave(
+		@PathVariable Long auctionId,
+		@AuthenticationPrincipal UserPrincipal userPrincipal) {
+
+		// TODO : UserPrincipal 이 유효한 값인지 확인하는 로직 추가 필요
+
+		// 채팅방 생성
+		CreateChatRoomResponse response = chatRoomService.addChatRoom(userPrincipal.getMemberEntity(), auctionId);
+
+		// 응답 생성
+		ResultDto<CreateChatRoomResponse> resultDto = ResultDto.res(
+			CHATROOM_CREATE_SUCCESS.getStatusCode(),
+			CHATROOM_CREATE_SUCCESS.getResultMsg(),
+			response
+		);
+
+		return ResponseEntity
+			.status(CHATROOM_CREATE_SUCCESS.getHttpStatus())
+			.body(resultDto);
+	}
+
+	// TODO : pagination 으로 변경하기
+	@GetMapping
+	public ResponseEntity<ResultDto<ChatRoomListResponse>> findChatRooms(
+		@AuthenticationPrincipal UserPrincipal userPrincipal
+	) {
+		log.info("Fetching all chat rooms for user ID: {}", userPrincipal.getMemberEntity().getMemberId());
+
+		// 채팅방 목록 조회
+		ChatRoomListResponse response = chatRoomService.findMyChatRooms(userPrincipal.getMemberEntity());
+
+		// 응답 생성
+		ResultDto<ChatRoomListResponse> resultDto = ResultDto.res(
+			CHATROOM_LIST_SUCCESS.getStatusCode(),
+			CHATROOM_LIST_SUCCESS.getResultMsg(),
+			response
+		);
+
+		return ResponseEntity
+			.status(CHATROOM_LIST_SUCCESS.getHttpStatus())
+			.body(resultDto);
+	}
+
+}

--- a/omocha-client/src/main/java/org/auction/client/chat/interfaces/response/ChatRoomListResponse.java
+++ b/omocha-client/src/main/java/org/auction/client/chat/interfaces/response/ChatRoomListResponse.java
@@ -1,0 +1,9 @@
+package org.auction.client.chat.interfaces.response;
+
+import java.util.List;
+
+public record ChatRoomListResponse(
+	List<CreateChatRoomResponse> chatRooms
+) {
+
+}

--- a/omocha-client/src/main/java/org/auction/client/chat/interfaces/response/CreateChatRoomResponse.java
+++ b/omocha-client/src/main/java/org/auction/client/chat/interfaces/response/CreateChatRoomResponse.java
@@ -1,0 +1,34 @@
+package org.auction.client.chat.interfaces.response;
+
+import java.time.LocalDateTime;
+
+import org.auction.domain.chat.domain.entity.ChatRoomEntity;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+
+public record CreateChatRoomResponse(
+	Long roomId, // 채팅방 ID
+	String roomName, // 경매 TITLE
+	Long sellerId, // 판매자 ID
+	String sellerName, // 판매자 NAME
+	Long nowPrice, // 경매 현재 가격 -> 낙찰 가격으로 수정해야함
+	Long buyerId, // 구매자 ID
+	String buyerName,
+	@JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd HH:mm:ss")
+	LocalDateTime createdDate
+) {
+
+	public static CreateChatRoomResponse toDto(ChatRoomEntity chatRoomEntity) {
+		return new CreateChatRoomResponse(
+			chatRoomEntity.getChatRoomId(),
+			chatRoomEntity.getRoomName(),
+			chatRoomEntity.getSeller().getMemberId(),
+			chatRoomEntity.getSeller().getNickname(),
+			chatRoomEntity.getNowPrice(),
+			chatRoomEntity.getBuyer().getMemberId(),
+			chatRoomEntity.getBuyer().getNickname(),
+			chatRoomEntity.getCreatedAt()
+		);
+	}
+
+}

--- a/omocha-client/src/main/java/org/auction/client/chat/interfaces/response/CreateChatRoomResponse.java
+++ b/omocha-client/src/main/java/org/auction/client/chat/interfaces/response/CreateChatRoomResponse.java
@@ -7,6 +7,7 @@ import org.auction.domain.chat.domain.entity.ChatRoomEntity;
 import com.fasterxml.jackson.annotation.JsonFormat;
 
 public record CreateChatRoomResponse(
+	Long auctionId, // 경매 ID
 	Long roomId, // 채팅방 ID
 	String roomName, // 경매 TITLE
 	Long sellerId, // 판매자 ID
@@ -20,6 +21,7 @@ public record CreateChatRoomResponse(
 
 	public static CreateChatRoomResponse toDto(ChatRoomEntity chatRoomEntity) {
 		return new CreateChatRoomResponse(
+			chatRoomEntity.getAuctionId(),
 			chatRoomEntity.getChatRoomId(),
 			chatRoomEntity.getRoomName(),
 			chatRoomEntity.getSeller().getMemberId(),

--- a/omocha-client/src/main/java/org/auction/client/common/code/BidCode.java
+++ b/omocha-client/src/main/java/org/auction/client/common/code/BidCode.java
@@ -13,6 +13,9 @@ public enum BidCode {
 	BIDDING_CREATE_SUCCESS(HttpStatus.OK, "성공적으로 입찰되었습니다."),
 	BIDDING_GET_SUCCESS(HttpStatus.OK, "성공적으로 입찰을 불러왔습니다."),
 
+	// EXPLAIN : 400 ERROR 응답 코드
+	NO_BIDS_FOUND(HttpStatus.BAD_REQUEST, "입찰이 존재하지 않습니다."),
+
 	// EXPLAIN: 404 Not Found 응답 코드
 
 	// EXPLAIN: 500 Internal Server Error 응답 코드

--- a/omocha-client/src/main/java/org/auction/client/config/chat/WebSocketConfig.java
+++ b/omocha-client/src/main/java/org/auction/client/config/chat/WebSocketConfig.java
@@ -1,0 +1,28 @@
+package org.auction.client.config.chat;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.messaging.simp.config.MessageBrokerRegistry;
+import org.springframework.web.socket.config.annotation.EnableWebSocketMessageBroker;
+import org.springframework.web.socket.config.annotation.StompEndpointRegistry;
+import org.springframework.web.socket.config.annotation.WebSocketMessageBrokerConfigurer;
+
+@Configuration
+@EnableWebSocketMessageBroker
+public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
+
+	@Override
+	public void configureMessageBroker(MessageBrokerRegistry config) {
+		// 클라이언트에서 구독할 endpoint를 설정합니다.
+		config.enableSimpleBroker("/sub");
+
+		// 클라이언트에서 메시지를 발행할 endpoint를 설정합니다.
+		config.setApplicationDestinationPrefixes("/pub");
+	}
+
+	@Override
+	public void registerStompEndpoints(StompEndpointRegistry registry) {
+		registry.addEndpoint("/omocha-websocket")
+			.setAllowedOriginPatterns("*")
+			.withSockJS();
+	}
+}

--- a/omocha-client/src/main/java/org/auction/client/config/swagger/SwaggerConfig.java
+++ b/omocha-client/src/main/java/org/auction/client/config/swagger/SwaggerConfig.java
@@ -37,7 +37,8 @@ public class SwaggerConfig {
 
 	@Bean
 	public GroupedOpenApi customTestOpenAPI() {
-		String[] paths = {"/api/v1/auction/*", "/api/v1/auction", "/api/v1/auth/*", "/api/v1/bid/*"};
+		String[] paths = {"/api/v1/auction/*", "/api/v1/auction", "/api/v1/auth/*", "/api/v1/bid/*",
+			"/api/v1/chatroom/*"};
 
 		return GroupedOpenApi.builder()
 			.group("사용자를 위한 API")

--- a/omocha-client/src/main/java/org/auction/client/config/swagger/SwaggerConfig.java
+++ b/omocha-client/src/main/java/org/auction/client/config/swagger/SwaggerConfig.java
@@ -38,7 +38,7 @@ public class SwaggerConfig {
 	@Bean
 	public GroupedOpenApi customTestOpenAPI() {
 		String[] paths = {"/api/v1/auction/*", "/api/v1/auction", "/api/v1/auth/*", "/api/v1/bid/*",
-			"/api/v1/chatroom/*"};
+			"/api/v1/chatroom/**"};
 
 		return GroupedOpenApi.builder()
 			.group("사용자를 위한 API")

--- a/omocha-client/src/main/java/org/auction/client/exception/GlobalExceptionHandler.java
+++ b/omocha-client/src/main/java/org/auction/client/exception/GlobalExceptionHandler.java
@@ -5,6 +5,7 @@ import static org.auction.client.common.code.AuctionCode.*;
 import org.auction.client.common.dto.ResultDto;
 import org.auction.client.exception.auction.AuctionException;
 import org.auction.client.exception.bid.BidException;
+import org.auction.client.exception.chat.ChatException;
 import org.auction.client.exception.image.ImageException;
 import org.auction.client.exception.jwt.JwtTokenException;
 import org.auction.client.exception.member.MemberException;
@@ -123,6 +124,23 @@ public class GlobalExceptionHandler {
 		);
 		return ResponseEntity
 			.status(e.getMemberCode().getHttpStatus())
+			.body(resultDto);
+	}
+
+	@ExceptionHandler(ChatException.class)
+	public ResponseEntity<ResultDto<Object>> handleMemberException(
+		ChatException e,
+		HttpServletRequest request
+	) {
+		log.error("errorCode: {}, url: {}, message: {}",
+			e.getChatCode(), request.getRequestURI(), e.getDetailMessage(), e);
+
+		ResultDto<Object> resultDto = ResultDto.res(
+			e.getChatCode().getStatusCode(),
+			e.getChatCode().getResultMsg()
+		);
+		return ResponseEntity
+			.status(e.getChatCode().getHttpStatus())
 			.body(resultDto);
 	}
 

--- a/omocha-client/src/main/java/org/auction/client/exception/bid/NoBidsException.java
+++ b/omocha-client/src/main/java/org/auction/client/exception/bid/NoBidsException.java
@@ -1,0 +1,18 @@
+package org.auction.client.exception.bid;
+
+import org.auction.client.common.code.BidCode;
+
+public class NoBidsException extends BidException {
+	public NoBidsException(
+		BidCode bidCode
+	) {
+		super(bidCode);
+	}
+
+	public NoBidsException(
+		BidCode bidCode,
+		String detailMessage
+	) {
+		super(bidCode, detailMessage);
+	}
+}

--- a/omocha-client/src/main/java/org/auction/client/exception/chat/ChatException.java
+++ b/omocha-client/src/main/java/org/auction/client/exception/chat/ChatException.java
@@ -1,0 +1,30 @@
+package org.auction.client.exception.chat;
+
+import org.auction.client.common.code.ChatCode;
+
+import lombok.Getter;
+
+@Getter
+public class ChatException extends RuntimeException {
+
+	private final ChatCode chatCode;
+	private final String detailMessage;
+
+	public ChatException(
+		ChatCode chatCode
+	) {
+		super(chatCode.getResultMsg());
+		this.chatCode = chatCode;
+		this.detailMessage = chatCode.getResultMsg();
+	}
+
+	public ChatException(
+		ChatCode chatCode,
+		String detailMessage
+	) {
+		super(chatCode.getResultMsg());
+		this.chatCode = chatCode;
+		this.detailMessage = detailMessage;
+	}
+
+}

--- a/omocha-client/src/main/java/org/auction/client/exception/chat/ChatRoomAccessException.java
+++ b/omocha-client/src/main/java/org/auction/client/exception/chat/ChatRoomAccessException.java
@@ -1,0 +1,19 @@
+package org.auction.client.exception.chat;
+
+import org.auction.client.common.code.ChatCode;
+
+public class ChatRoomAccessException extends ChatException {
+
+	public ChatRoomAccessException(
+		ChatCode chatCode
+	) {
+		super(chatCode);
+	}
+
+	public ChatRoomAccessException(
+		ChatCode chatCode,
+		String detailMessage
+	) {
+		super(chatCode, detailMessage);
+	}
+}

--- a/omocha-client/src/main/java/org/auction/client/exception/chat/ChatRoomAlreadyExistsException.java
+++ b/omocha-client/src/main/java/org/auction/client/exception/chat/ChatRoomAlreadyExistsException.java
@@ -1,0 +1,18 @@
+package org.auction.client.exception.chat;
+
+import org.auction.client.common.code.ChatCode;
+
+public class ChatRoomAlreadyExistsException extends ChatException {
+	public ChatRoomAlreadyExistsException(
+		ChatCode chatCode
+	) {
+		super(chatCode);
+	}
+
+	public ChatRoomAlreadyExistsException(
+		ChatCode chatCode,
+		String detailMessage
+	) {
+		super(chatCode, detailMessage);
+	}
+}

--- a/omocha-client/src/main/java/org/auction/client/exception/chat/ChatRoomNotFoundException.java
+++ b/omocha-client/src/main/java/org/auction/client/exception/chat/ChatRoomNotFoundException.java
@@ -1,0 +1,18 @@
+package org.auction.client.exception.chat;
+
+import org.auction.client.common.code.ChatCode;
+
+public class ChatRoomNotFoundException extends ChatException {
+	public ChatRoomNotFoundException(
+		ChatCode chatCode
+	) {
+		super(chatCode);
+	}
+
+	public ChatRoomNotFoundException(
+		ChatCode chatCode,
+		String detailMessage
+	) {
+		super(chatCode, detailMessage);
+	}
+}

--- a/omocha-client/src/main/java/org/auction/client/exception/chat/SellerIsBuyerException.java
+++ b/omocha-client/src/main/java/org/auction/client/exception/chat/SellerIsBuyerException.java
@@ -1,0 +1,18 @@
+package org.auction.client.exception.chat;
+
+import org.auction.client.common.code.ChatCode;
+
+public class SellerIsBuyerException extends ChatException {
+	public SellerIsBuyerException(
+		ChatCode chatCode
+	) {
+		super(chatCode);
+	}
+
+	public SellerIsBuyerException(
+		ChatCode chatCode,
+		String detailMessage
+	) {
+		super(chatCode, detailMessage);
+	}
+}

--- a/omocha-domain/src/main/java/org/auction/domain/auction/infrastructure/custom/AuctionRepositoryImpl.java
+++ b/omocha-domain/src/main/java/org/auction/domain/auction/infrastructure/custom/AuctionRepositoryImpl.java
@@ -56,7 +56,7 @@ public class AuctionRepositoryImpl implements AuctionRepositoryCustom {
 		JPAQuery<AuctionEntity> query = queryFactory
 			.selectDistinct(auctionEntity)
 			.from(auctionEntity)
-			.leftJoin(auctionEntity.images, imageEntity).fetchJoin()
+			.leftJoin(auctionEntity.images, imageEntity)
 			.where(
 				titleContains(condition.title()),
 				statusEquals(auctionStatus)
@@ -82,9 +82,9 @@ public class AuctionRepositoryImpl implements AuctionRepositoryCustom {
 		JPAQuery<Long> countQuery = queryFactory
 			.select(auctionEntity.count())
 			.from(auctionEntity)
-			.leftJoin(auctionEntity.images, imageEntity)
 			.where(
-				titleContains(condition.title())
+				titleContains(condition.title()),
+				statusEquals(auctionStatus)
 			);
 
 		return PageableExecutionUtils.getPage(auctions, pageable, countQuery::fetchOne);

--- a/omocha-domain/src/main/java/org/auction/domain/chat/domain/entity/ChatRoomEntity.java
+++ b/omocha-domain/src/main/java/org/auction/domain/chat/domain/entity/ChatRoomEntity.java
@@ -1,0 +1,61 @@
+package org.auction.domain.chat.domain.entity;
+
+import org.auction.domain.common.domain.entity.TimeTrackableEntity;
+import org.auction.domain.member.domain.entity.MemberEntity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "chatroom")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+public class ChatRoomEntity extends TimeTrackableEntity {
+
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	@Column(name = "chat_room_id")
+	private Long chatRoomId;
+
+	@Column(name = "room_name", nullable = false)
+	private String roomName;
+
+	@Column(name = "now_price", nullable = false)
+	private Long nowPrice;
+
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "buyer_id", nullable = false)
+	private MemberEntity buyer;
+
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "seller_id", nullable = false)
+	private MemberEntity seller;
+
+	@Builder
+	public ChatRoomEntity(
+		String roomName,
+		Long nowPrice,
+		MemberEntity buyer,
+		MemberEntity seller
+	) {
+		this.roomName = roomName;
+		this.nowPrice = nowPrice;
+		this.buyer = buyer;
+		this.seller = seller;
+	}
+
+	public boolean validateParticipant(MemberEntity member) {
+		return buyer.equals(member) || seller.equals(member);
+	}
+}

--- a/omocha-domain/src/main/java/org/auction/domain/chat/domain/entity/ChatRoomEntity.java
+++ b/omocha-domain/src/main/java/org/auction/domain/chat/domain/entity/ChatRoomEntity.java
@@ -59,10 +59,5 @@ public class ChatRoomEntity extends TimeTrackableEntity {
 		this.seller = seller;
 		this.auctionId = auctionId;
 	}
-
-	public boolean validateParticipant(
-		MemberEntity member
-	) {
-		return buyer.equals(member) || seller.equals(member);
-	}
+	
 }

--- a/omocha-domain/src/main/java/org/auction/domain/chat/domain/entity/ChatRoomEntity.java
+++ b/omocha-domain/src/main/java/org/auction/domain/chat/domain/entity/ChatRoomEntity.java
@@ -42,20 +42,27 @@ public class ChatRoomEntity extends TimeTrackableEntity {
 	@JoinColumn(name = "seller_id", nullable = false)
 	private MemberEntity seller;
 
+	@Column(name = "auction_id", nullable = false)
+	private Long auctionId;
+
 	@Builder
 	public ChatRoomEntity(
 		String roomName,
 		Long nowPrice,
 		MemberEntity buyer,
-		MemberEntity seller
+		MemberEntity seller,
+		Long auctionId
 	) {
 		this.roomName = roomName;
 		this.nowPrice = nowPrice;
 		this.buyer = buyer;
 		this.seller = seller;
+		this.auctionId = auctionId;
 	}
 
-	public boolean validateParticipant(MemberEntity member) {
+	public boolean validateParticipant(
+		MemberEntity member
+	) {
 		return buyer.equals(member) || seller.equals(member);
 	}
 }

--- a/omocha-domain/src/main/java/org/auction/domain/chat/domain/enums/MessageType.java
+++ b/omocha-domain/src/main/java/org/auction/domain/chat/domain/enums/MessageType.java
@@ -1,0 +1,8 @@
+package org.auction.domain.chat.domain.enums;
+
+public enum MessageType {
+	ENTER,
+	CHAT,
+	JOIN,
+	LEAVE
+}

--- a/omocha-domain/src/main/java/org/auction/domain/chat/infrastructure/ChatRoomRepository.java
+++ b/omocha-domain/src/main/java/org/auction/domain/chat/infrastructure/ChatRoomRepository.java
@@ -1,0 +1,19 @@
+package org.auction.domain.chat.infrastructure;
+
+import java.util.List;
+
+import org.auction.domain.auction.domain.entity.AuctionEntity;
+import org.auction.domain.chat.domain.entity.ChatRoomEntity;
+import org.auction.domain.member.domain.entity.MemberEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ChatRoomRepository extends JpaRepository<ChatRoomEntity, Long> {
+	// 특정 채팅방 이름으로 채팅방의 존재 여부 확인
+	boolean existsByRoomName(String roomName);
+
+	// 특정 회원이 참여한 모든 채팅방 조회
+	List<ChatRoomEntity> findByBuyerOrSeller(MemberEntity buyer, MemberEntity seller);
+
+	// 특정 경매와 구매자에 대한 채팅 존재 유무 확인
+	boolean existsByAuctionEntityAndBuyer(AuctionEntity auctionEntity, MemberEntity buyer);
+}

--- a/omocha-domain/src/main/java/org/auction/domain/chat/infrastructure/ChatRoomRepository.java
+++ b/omocha-domain/src/main/java/org/auction/domain/chat/infrastructure/ChatRoomRepository.java
@@ -7,8 +7,8 @@ import org.auction.domain.member.domain.entity.MemberEntity;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface ChatRoomRepository extends JpaRepository<ChatRoomEntity, Long> {
-	// 특정 채팅방 이름으로 채팅방의 존재 여부 확인
-	boolean existsByRoomName(String roomName);
+	// 특정 경매 ID로 채팅방의 존재 여부 확인
+	boolean existsByAuctionId(Long auctionId);
 
 	// 특정 회원이 참여한 모든 채팅방 조회
 	List<ChatRoomEntity> findByBuyerOrSeller(MemberEntity buyer, MemberEntity seller);

--- a/omocha-domain/src/main/java/org/auction/domain/chat/infrastructure/ChatRoomRepository.java
+++ b/omocha-domain/src/main/java/org/auction/domain/chat/infrastructure/ChatRoomRepository.java
@@ -2,7 +2,6 @@ package org.auction.domain.chat.infrastructure;
 
 import java.util.List;
 
-import org.auction.domain.auction.domain.entity.AuctionEntity;
 import org.auction.domain.chat.domain.entity.ChatRoomEntity;
 import org.auction.domain.member.domain.entity.MemberEntity;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -14,6 +13,4 @@ public interface ChatRoomRepository extends JpaRepository<ChatRoomEntity, Long> 
 	// 특정 회원이 참여한 모든 채팅방 조회
 	List<ChatRoomEntity> findByBuyerOrSeller(MemberEntity buyer, MemberEntity seller);
 
-	// 특정 경매와 구매자에 대한 채팅 존재 유무 확인
-	boolean existsByAuctionEntityAndBuyer(AuctionEntity auctionEntity, MemberEntity buyer);
 }

--- a/omocha-domain/src/main/java/org/auction/domain/member/domain/entity/MemberEntity.java
+++ b/omocha-domain/src/main/java/org/auction/domain/member/domain/entity/MemberEntity.java
@@ -1,5 +1,7 @@
 package org.auction.domain.member.domain.entity;
 
+import java.util.Objects;
+
 import org.auction.domain.common.domain.entity.TimeTrackableEntity;
 import org.auction.domain.member.domain.enums.Role;
 import org.auction.domain.member.domain.enums.UserStatus;
@@ -38,7 +40,7 @@ public class MemberEntity extends TimeTrackableEntity {
 
 	@Column(name = "username")
 	private String username;
-	
+
 	@Column(name = "birth")
 	private String birth;
 
@@ -84,5 +86,20 @@ public class MemberEntity extends TimeTrackableEntity {
 		this.provider = provider;
 		this.providerId = providerId;
 		this.userStatus = userStatus;
+	}
+
+	@Override
+	public boolean equals(Object o) {
+		if (this == o)
+			return true;
+		if (o == null || getClass() != o.getClass())
+			return false;
+		MemberEntity that = (MemberEntity)o;
+		return Objects.equals(memberId, that.memberId) && Objects.equals(nickname, that.nickname);
+	}
+
+	@Override
+	public int hashCode() {
+		return Objects.hash(memberId, nickname);
 	}
 }

--- a/omocha-domain/src/main/java/org/auction/domain/member/domain/entity/MemberEntity.java
+++ b/omocha-domain/src/main/java/org/auction/domain/member/domain/entity/MemberEntity.java
@@ -1,7 +1,5 @@
 package org.auction.domain.member.domain.entity;
 
-import java.util.Objects;
-
 import org.auction.domain.common.domain.entity.TimeTrackableEntity;
 import org.auction.domain.member.domain.enums.Role;
 import org.auction.domain.member.domain.enums.UserStatus;
@@ -86,20 +84,5 @@ public class MemberEntity extends TimeTrackableEntity {
 		this.provider = provider;
 		this.providerId = providerId;
 		this.userStatus = userStatus;
-	}
-
-	@Override
-	public boolean equals(Object o) {
-		if (this == o)
-			return true;
-		if (o == null || getClass() != o.getClass())
-			return false;
-		MemberEntity that = (MemberEntity)o;
-		return Objects.equals(memberId, that.memberId) && Objects.equals(nickname, that.nickname);
-	}
-
-	@Override
-	public int hashCode() {
-		return Objects.hash(memberId, nickname);
 	}
 }


### PR DESCRIPTION
## What is this PR? 🔍

- 기능 : 채팅방 생성, 조회 구현
- issue : #50 

## Changes 📝

### 1. **채팅방 생성**

- **HTTP 메서드:** `POST`
- **엔드포인트:** `http://localhost:8080/api/v1/chatroom/{auctionId}`

#### **요청 파라미터**
현재는 `auctionId`를 통해 채팅방을 생성 (추후 자동 채팅방 생성 예정)

#### **응답 예시**
```json
{
    "status_code": 201,
    "result_msg": "채팅방 생성 성공",
    "result_data": {
        "auction_id": 1,
        "room_id": 1,
        "room_name": "Vintage4",
        "seller_id": 2,
        "seller_name": null,
        "now_price": 50000,
        "buyer_id": 1,
        "buyer_name": null,
        "created_date": "2024-10-11 19:12:38"
    }
}
```


### 채팅방 생성 조건

채팅방이 생성되려면 조건을 충족해야함

- **경매가 존재해야 한다**: BIDDING이 종료된 경매만 채팅방을 생성
- **판매자와 구매자가 동일할 수 없다**: 구매자가 판매자일 경우 채팅방이 생성안됨
- **입찰이 없는 경매는 채팅방을 생성할 수 없다**: 입찰 기록이 없는 경매는 채팅방이 생성안됨
- **채팅방이 이미 존재하는 경우 생성되지 않는다**: 같은 경매에 대해 이미 생성된 채팅방이 있을 경우, 중복 생성이 허용 X

### 나의 채팅방 전체 리스트 조회

- **HTTP 메서드:** `GET`
- **엔드포인트:** `http://localhost:8080/api/v1/chatroom`

#### 응답 예시

```json
{
    "status_code": 200,
    "result_msg": "채팅방 목록 조회 성공",
    "result_data": {
        "chat_rooms": [
            {
                "auction_id": 1,
                "room_id": 1,
                "room_name": "Vintage4",
                "seller_id": 2,
                "seller_name": null,
                "now_price": 50000,
                "buyer_id": 1,
                "buyer_name": null,
                "created_date": "2024-10-11 19:12:38"
            }
        ]
    }
}
```

## Precaution

- 채팅방에 있는 메세지 조회 그리고 채팅방 상세 조회 구현해야함

## ✔️ Please check if the PR fulfills these requirements

- [ ] It's submitted to the correct branch, not the `develop` branch unconditionally?
- [ ] If on a hotfix branch, ensure it targets `main`?
- [ ] There are no warning message when you run `yarn lint`

- Close #ISSUE_NUMBER
