### PR TITLE
[FIX] fetchjoin 제거 후 @BatchSize 사용

### DIFF
--- a/omocha-domain/src/main/java/org/auction/domain/auction/domain/entity/AuctionEntity.java
+++ b/omocha-domain/src/main/java/org/auction/domain/auction/domain/entity/AuctionEntity.java
@@ -9,6 +9,7 @@ import org.auction.domain.auction.domain.enums.AuctionType;
 import org.auction.domain.common.domain.entity.TimeTrackableEntity;
 import org.auction.domain.image.domain.entity.ImageEntity;
 import org.auction.domain.member.domain.entity.MemberEntity;
+import org.hibernate.annotations.BatchSize;
 
 import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
@@ -67,6 +68,7 @@ public class AuctionEntity extends TimeTrackableEntity {
 	@Column(name = "end_date", nullable = false)
 	private LocalDateTime endDate;
 
+	@BatchSize(size = 10)
 	@OneToMany(mappedBy = "auctionEntity", fetch = FetchType.LAZY,
 		cascade = CascadeType.ALL, orphanRemoval = true)
 	private List<ImageEntity> images = new ArrayList<>();


### PR DESCRIPTION
## What is this PR? 🔍

- **기능**: `@BatchSize`를 사용하여 `fetchJoin` 문제 해결
- **Issue**: #54 

## Changes 📝

- `@BatchSize`를 사용하여 `@OneToMany` 관계에서 `FetchJoin`을 사용할 때 발생하는 오류 해결.
- **오류 사항**
  - `firstResult/maxResults specified with collection fetch; applying in memory`
  - **문제점**: 페이징(pagination)이 제대로 동작하지 않음.
  - **문제점**: count query가 제대로 동작하지 않음.


## Precaution
- 다른 개선 기법을 사용 : @BatchSize(10)으로 설정했는데, BatchSize 설정은 대규모 데이터를 처리할 때 사용하는 걸로 알고있습니다. 추후에 공부를 더 해서 다른 해결 방법도 찾아볼 예정입니다.

## ✔️ Please check if the PR fulfills these requirements

- [ ] It's submitted to the correct branch, not the `develop` branch unconditionally?
- [ ] If on a hotfix branch, ensure it targets `main`?
- [ ] There are no warning message when you run `yarn lint`

- Close #54 
