### PR TITLE
[FIX] WebSocketConfig setAllowedOriginPatterns 추가

### DIFF
--- a/omocha-client/src/main/java/org/auction/client/config/chat/WebSocketConfig.java
+++ b/omocha-client/src/main/java/org/auction/client/config/chat/WebSocketConfig.java
@@ -30,7 +30,8 @@ public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
 		StompEndpointRegistry registry
 	) {
 		registry.addEndpoint("/omocha-websocket")
-			.setAllowedOriginPatterns(domain)
+			.setAllowedOriginPatterns("https://local.omocha-auction.com", "https://api.omocha-auction.com",
+				"http://localhost:8080", "http://localhost:3000")
 			.withSockJS();
 	}
 }

--- a/omocha-client/src/main/java/org/auction/client/config/chat/WebSocketConfig.java
+++ b/omocha-client/src/main/java/org/auction/client/config/chat/WebSocketConfig.java
@@ -31,7 +31,7 @@ public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
 	) {
 		registry.addEndpoint("/omocha-websocket")
 			.setAllowedOriginPatterns("https://local.omocha-auction.com", "https://api.omocha-auction.com",
-				"http://localhost:8080", "http://localhost:3000")
+				"http://localhost:8080", "http://localhost:3000", "https://www.omocha-auction.com")
 			.withSockJS();
 	}
 }

--- a/omocha-client/src/main/resources/application.yml
+++ b/omocha-client/src/main/resources/application.yml
@@ -2,7 +2,7 @@ spring:
   application:
     name: omocha
   profiles:
-    active: local # 개발 환경에 따라 변경할 것 (local | prod)
+    active: prod # 개발 환경에 따라 변경할 것 (local | prod)
   output:
     ansi:
       enabled: always

--- a/omocha-client/src/main/resources/application.yml
+++ b/omocha-client/src/main/resources/application.yml
@@ -2,7 +2,7 @@ spring:
   application:
     name: omocha
   profiles:
-    active: prod # 개발 환경에 따라 변경할 것 (local | prod)
+    active: local # 개발 환경에 따라 변경할 것 (local | prod)
   output:
     ansi:
       enabled: always


### PR DESCRIPTION
## What is this PR? 🔍

- 기능 : setAllowedOriginPatterns 추가
- issue : #86 

## Changes 📝

### 코드 설명
- **`addEndpoint`**: `/omocha-websocket` 경로로 WebSocket 연결을 수립할 엔드포인트를 추가
- **`setAllowedOriginPatterns`**: 허용할 CORS 출처를 지정합니다. 아래 도메인들로부터의 연결을 허용:
  - `https://local.omocha-auction.com`
  - `https://api.omocha-auction.com`
  - `http://localhost:8080`
  - `http://localhost:3000`
  - `https://www.omocha-auction.com`
- **`withSockJS`**: SockJS를 사용하여 WebSocket 기능을 폴백 처리
### 코드 예시
```java
@Override
public void registerStompEndpoints(StompEndpointRegistry registry) {
    registry.addEndpoint("/omocha-websocket")
        .setAllowedOriginPatterns(
            "https://local.omocha-auction.com", 
            "https://api.omocha-auction.com",
            "http://localhost:8080", 
            "http://localhost:3000", 
            "https://www.omocha-auction.com"
        )
        .withSockJS();
}
```

## Precaution

일단은 test 하기 위해서 setAllowedOriginPatterns에 다 추가했습니다. 추후에 수정할 예정입니다.

## ✔️ Please check if the PR fulfills these requirements

- [ ] It's submitted to the correct branch, not the `develop` branch unconditionally?
- [ ] If on a hotfix branch, ensure it targets `main`?
- [ ] There are no warning message when you run `yarn lint`

- Close #ISSUE_NUMBER
