### PR TITLE
[FIX] ChatController 수정, 유저 정보 프론트에서 받음

### DIFF
--- a/omocha-client/src/main/java/org/auction/client/chat/application/ChatService.java
+++ b/omocha-client/src/main/java/org/auction/client/chat/application/ChatService.java
@@ -26,8 +26,13 @@ public class ChatService {
 	private final ChatRepository chatRepository;
 	private final ChatRoomRepository roomRepository;
 
-	public ChatEntity createChat(Long roomId, MemberEntity sender, String message, MessageType type) {
-		
+	public ChatEntity createChat(
+		Long roomId,
+		MemberEntity sender,
+		String message,
+		MessageType type
+	) {
+
 		// 채팅방 조회
 		ChatRoomEntity room = roomRepository.findById(roomId)
 			.orElseThrow(() -> new ChatRoomNotFoundException(CHATROOM_NOT_FOUND));

--- a/omocha-client/src/main/java/org/auction/client/chat/interfaces/ChatController.java
+++ b/omocha-client/src/main/java/org/auction/client/chat/interfaces/ChatController.java
@@ -1,16 +1,14 @@
 package org.auction.client.chat.interfaces;
 
-import org.auction.client.chat.application.ChatRoomService;
 import org.auction.client.chat.application.ChatService;
 import org.auction.client.chat.interfaces.request.ChatMessageRequest;
 import org.auction.client.chat.interfaces.response.ChatMessageResponse;
-import org.auction.client.jwt.UserPrincipal;
+import org.auction.client.member.application.MemberService;
 import org.auction.domain.chat.domain.entity.ChatEntity;
 import org.auction.domain.member.domain.entity.MemberEntity;
 import org.springframework.messaging.handler.annotation.DestinationVariable;
 import org.springframework.messaging.handler.annotation.MessageMapping;
 import org.springframework.messaging.simp.SimpMessageSendingOperations;
-import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.stereotype.Controller;
 
 import lombok.RequiredArgsConstructor;
@@ -23,18 +21,18 @@ public class ChatController {
 
 	private final SimpMessageSendingOperations messagingTemplate;
 	private final ChatService chatService;
-	private final ChatRoomService chatRoomService;
+	private final MemberService memberService;
 
 	@MessageMapping("/{roomId}/messages")
 	public void chat(
 		@DestinationVariable("roomId") Long roomId,
-		ChatMessageRequest chatRequest,
-		@AuthenticationPrincipal UserPrincipal userPrincipal
+		ChatMessageRequest chatRequest
 	) {
 
 		log.info("Received message: {}", chatRequest);
 
-		MemberEntity member = userPrincipal.getMemberEntity();
+		MemberEntity member =
+			memberService.findMemberByMemberId(chatRequest.senderId());
 
 		// 채팅 메시지 저장
 		ChatEntity chat = chatService.createChat(

--- a/omocha-client/src/main/java/org/auction/client/chat/interfaces/request/ChatMessageRequest.java
+++ b/omocha-client/src/main/java/org/auction/client/chat/interfaces/request/ChatMessageRequest.java
@@ -7,6 +7,7 @@ import jakarta.validation.constraints.NotBlank;
 public record ChatMessageRequest(
 	@NotBlank
 	MessageType messageType,
+	Long senderId,
 	@NotBlank
 	String message
 ) {

--- a/omocha-client/src/main/resources/application.yml
+++ b/omocha-client/src/main/resources/application.yml
@@ -2,7 +2,7 @@ spring:
   application:
     name: omocha
   profiles:
-    active: local # 개발 환경에 따라 변경할 것 (local | prod)
+    active: prod # 개발 환경에 따라 변경할 것 (local | prod)
   output:
     ansi:
       enabled: always

--- a/omocha-client/src/main/resources/application.yml
+++ b/omocha-client/src/main/resources/application.yml
@@ -2,7 +2,7 @@ spring:
   application:
     name: omocha
   profiles:
-    active: prod # 개발 환경에 따라 변경할 것 (local | prod)
+    active: local # 개발 환경에 따라 변경할 것 (local | prod)
   output:
     ansi:
       enabled: always


### PR DESCRIPTION
## What is this PR? 🔍

- 기능 : ChatController 수정
- issue : #90 

## Changes 📝

Spring에서 WebSocket 연결 시 **@AuthenticationPrincipal**로 전달되는 유저 정보를 못 받음. 

그래서 프론트에서 UserId를 받아서 해결했다.


## Precaution

## ✔️ Please check if the PR fulfills these requirements

- [ ] It's submitted to the correct branch, not the `develop` branch unconditionally?
- [ ] If on a hotfix branch, ensure it targets `main`?
- [ ] There are no warning message when you run `yarn lint`

- Close #ISSUE_NUMBER
