### PR TITLE
[FEAT] 아이디 중복체크 API 추가 및 회원 컬럼 수정

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,4 +5,4 @@ LABEL authors="omocha"
 COPY build/libs/omocha-api.jar /docker-springboot.jar
 
 # ENTRYPOINT를 수정하여 prod 프로파일 활성화
-ENTRYPOINT ["java", "-Dspring.profiles.active=prod", "-jar", "/docker-springboot.jar"]
+ENTRYPOINT ["java", "-Dspring.profiles.active=prod", "-jar", "/docker-springboot.jar", "-Duser.timezone=Asia/Seoul"]

--- a/omocha-client/src/main/java/org/auction/client/chat/interfaces/ChatController.java
+++ b/omocha-client/src/main/java/org/auction/client/chat/interfaces/ChatController.java
@@ -32,7 +32,7 @@ public class ChatController {
 		log.info("Received message: {}", chatRequest);
 
 		MemberEntity member =
-			memberService.findMemberByMemberId(chatRequest.senderId());
+			memberService.findMember(chatRequest.senderId());
 
 		// 채팅 메시지 저장
 		ChatEntity chat = chatService.createChat(

--- a/omocha-client/src/main/java/org/auction/client/exception/member/MemberEmailAlreadyExistsException.java
+++ b/omocha-client/src/main/java/org/auction/client/exception/member/MemberEmailAlreadyExistsException.java
@@ -2,14 +2,14 @@ package org.auction.client.exception.member;
 
 import org.auction.client.common.code.MemberCode;
 
-public class MemberAlreadyExistsException extends MemberException {
-	public MemberAlreadyExistsException(
+public class MemberEmailAlreadyExistsException extends MemberException {
+	public MemberEmailAlreadyExistsException(
 		MemberCode memberCode
 	) {
 		super(memberCode);
 	}
 
-	public MemberAlreadyExistsException(
+	public MemberEmailAlreadyExistsException(
 		MemberCode memberCode,
 		String detailMessage
 	) {

--- a/omocha-client/src/main/java/org/auction/client/jwt/application/CustomUserDetailsService.java
+++ b/omocha-client/src/main/java/org/auction/client/jwt/application/CustomUserDetailsService.java
@@ -19,7 +19,7 @@ public class CustomUserDetailsService implements UserDetailsService {
 	public UserPrincipal loadUserByUsername(
 		String memberIdStr
 	) throws UsernameNotFoundException {
-		MemberEntity memberEntity = memberService.findMemberByMemberId(Long.valueOf(memberIdStr));
+		MemberEntity memberEntity = memberService.findMember(Long.valueOf(memberIdStr));
 
 		return new UserPrincipal(memberEntity);
 	}

--- a/omocha-client/src/main/java/org/auction/client/jwt/application/JwtService.java
+++ b/omocha-client/src/main/java/org/auction/client/jwt/application/JwtService.java
@@ -1,7 +1,6 @@
 package org.auction.client.jwt.application;
 
 import java.security.Key;
-import java.util.function.Function;
 
 import javax.crypto.SecretKey;
 
@@ -19,7 +18,6 @@ import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.stereotype.Service;
 import org.springframework.util.StringUtils;
 
-import io.jsonwebtoken.Claims;
 import io.jsonwebtoken.Jwts;
 import io.jsonwebtoken.security.Keys;
 import jakarta.annotation.PostConstruct;
@@ -47,8 +45,8 @@ public class JwtService {
 	private String REFRESH_SECRET;
 	private SecretKey accessKey;
 	private SecretKey refreshKey;
-	private final static long ACCESS_EXPIRATION = 1000L * 60L * 60L;
-	private final static long REFRESH_EXPIRATION = 1000L * 60L * 60L * 24L;
+	private final static long ACCESS_EXPIRATION = 1000L;
+	private final static long REFRESH_EXPIRATION = 1000L;
 
 	@PostConstruct
 	public void init() {
@@ -142,26 +140,7 @@ public class JwtService {
 		String refreshToken
 	) {
 		Long memberId = RefreshToken.findMemberIdByRefreshToken(refreshToken);
-		return memberService.findMemberByMemberId(memberId);
-	}
-
-	// TODO: AccessToken에서 Claim 데이터 가져오는 메서드 (추후 사용을 위해 남겨놓음)
-	private <T> T findClaimFromToken(
-		String token,
-		Key secretKey,
-		Function<Claims, T> claimsResolver
-	) {
-		if (jwtUtil.validateToken(token, secretKey)) {
-			return null;
-		}
-
-		final Claims claims = Jwts.parserBuilder()
-			.setSigningKey(accessKey)
-			.build()
-			.parseClaimsJws(token)
-			.getBody();
-
-		return claimsResolver.apply(claims);
+		return memberService.findMember(memberId);
 	}
 
 	public void logout(

--- a/omocha-client/src/main/java/org/auction/client/member/application/MemberService.java
+++ b/omocha-client/src/main/java/org/auction/client/member/application/MemberService.java
@@ -63,21 +63,17 @@ public class MemberService {
 		MemberEntity member = memberRepository.findByEmail(memberLoginRequest.email())
 			.orElseThrow(() -> new MemberNotFoundException(MEMBER_NOT_FOUND));
 
-		if (!validatePassword(memberLoginRequest, member)) {
-			return null;
-		}
+		validatePassword(memberLoginRequest, member);
 
 		return member;
 	}
 
-	private boolean validatePassword(
+	private void validatePassword(
 		MemberLoginRequest memberLoginRequest,
 		MemberEntity member
 	) {
 		if (!passwordEncoder.matches(memberLoginRequest.password(), member.getPassword())) {
 			throw new InvalidPasswordException(INVALID_PASSWORD);
 		}
-
-		return true;
 	}
 }

--- a/omocha-client/src/main/java/org/auction/client/member/application/MemberService.java
+++ b/omocha-client/src/main/java/org/auction/client/member/application/MemberService.java
@@ -3,10 +3,12 @@ package org.auction.client.member.application;
 import static org.auction.client.common.code.MemberCode.*;
 
 import org.auction.client.exception.member.InvalidPasswordException;
-import org.auction.client.exception.member.MemberAlreadyExistsException;
+import org.auction.client.exception.member.MemberEmailAlreadyExistsException;
 import org.auction.client.exception.member.MemberNotFoundException;
 import org.auction.client.member.interfaces.request.MemberCreateRequest;
+import org.auction.client.member.interfaces.request.MemberDuplicateRequest;
 import org.auction.client.member.interfaces.request.MemberLoginRequest;
+import org.auction.client.member.interfaces.response.MemberDetailResponse;
 import org.auction.domain.member.domain.entity.MemberEntity;
 import org.auction.domain.member.domain.enums.Role;
 import org.auction.domain.member.domain.enums.UserStatus;
@@ -23,49 +25,56 @@ public class MemberService {
 	private final MemberRepository memberRepository;
 	private final PasswordEncoder passwordEncoder;
 
-	public String addMember(
+	public MemberDetailResponse addMember(
 		MemberCreateRequest memberCreateRequest
 	) {
-		if (memberRepository.existsByLoginId(memberCreateRequest.loginId())) {
-			throw new MemberAlreadyExistsException(MEMBER_ALREADY_EXISTS);
+		if (memberRepository.existsByEmail(memberCreateRequest.email())) {
+			throw new MemberEmailAlreadyExistsException(MEMBER_ALREADY_EXISTS);
 		}
 
-		MemberEntity memberEntity = MemberEntity.builder()
-			.loginId(memberCreateRequest.loginId())
+		MemberEntity member = MemberEntity.builder()
+			.email(memberCreateRequest.email())
 			.password(passwordEncoder.encode(memberCreateRequest.password()))
 			.role(Role.ROLE_USER)
 			.userStatus(UserStatus.ACTIVATE)
 			.build();
 
-		return memberRepository.save(memberEntity).getLoginId();
+		return MemberDetailResponse.toDto(memberRepository.save(member));
 	}
 
-	// TODO : findMemberByMemberId와 findMemberByLoginId에서 에러가 발생했을 경우 각각 식별이 필요함
-	public MemberEntity findMemberByMemberId(
+	public boolean isEmailDuplicate(
+		MemberDuplicateRequest memberDuplicateRequest
+	) {
+		return memberRepository.existsByEmailAndProviderIsNull(memberDuplicateRequest.email());
+	}
+
+	// TODO : 아래 두개의 메서드에서 에러가 발생했을 경우 각각 식별이 필요함
+	//  Exception의 명확한 네이밍 => MemberNotFoundByIdException, MemberNotFoundByEmailException
+	public MemberEntity findMember(
 		Long memberId
 	) {
 		return memberRepository.findById(memberId)
 			.orElseThrow(() -> new MemberNotFoundException(MEMBER_NOT_FOUND));
 	}
 
-	public MemberEntity findMemberByLoginId(
+	public MemberEntity findMember(
 		MemberLoginRequest memberLoginRequest
 	) {
-		MemberEntity member = memberRepository.findByLoginId(memberLoginRequest.loginId())
+		MemberEntity member = memberRepository.findByEmail(memberLoginRequest.email())
 			.orElseThrow(() -> new MemberNotFoundException(MEMBER_NOT_FOUND));
 
-		if (!validateLogin(memberLoginRequest, member)) {
+		if (!validatePassword(memberLoginRequest, member)) {
 			return null;
 		}
 
 		return member;
 	}
 
-	private boolean validateLogin(
+	private boolean validatePassword(
 		MemberLoginRequest memberLoginRequest,
-		MemberEntity memberEntity
+		MemberEntity member
 	) {
-		if (!passwordEncoder.matches(memberLoginRequest.password(), memberEntity.getPassword())) {
+		if (!passwordEncoder.matches(memberLoginRequest.password(), member.getPassword())) {
 			throw new InvalidPasswordException(INVALID_PASSWORD);
 		}
 

--- a/omocha-client/src/main/java/org/auction/client/member/interfaces/AuthApi.java
+++ b/omocha-client/src/main/java/org/auction/client/member/interfaces/AuthApi.java
@@ -3,7 +3,9 @@ package org.auction.client.member.interfaces;
 import org.auction.client.common.dto.ResultDto;
 import org.auction.client.jwt.UserPrincipal;
 import org.auction.client.member.interfaces.request.MemberCreateRequest;
+import org.auction.client.member.interfaces.request.MemberDuplicateRequest;
 import org.auction.client.member.interfaces.request.MemberLoginRequest;
+import org.auction.client.member.interfaces.response.MemberDetailResponse;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 
@@ -29,9 +31,23 @@ public interface AuthApi {
 		@ApiResponse(responseCode = "500", description = "서버 오류가 발생했습니다.",
 			content = @Content(mediaType = "application/json", schema = @Schema(implementation = ResultDto.class)))
 	})
-	ResponseEntity<ResultDto<String>> memberAdd(
+	ResponseEntity<ResultDto<MemberDetailResponse>> memberAdd(
 		@Parameter(description = "회원 생성 데이터", required = true)
 		MemberCreateRequest memberCreateRequest
+	);
+
+	@Operation(summary = "회원 중복체크", description = "중복 회원이 있는지 확인합니다.")
+	@ApiResponses(value = {
+		@ApiResponse(responseCode = "200", description = "중복 회원이 존재하지 않습니다.",
+			content = @Content(mediaType = "application/json", schema = @Schema(implementation = ResultDto.class))),
+		@ApiResponse(responseCode = "400", description = "중복 회원이 존재합니다.",
+			content = @Content(mediaType = "application/json", schema = @Schema(implementation = ResultDto.class))),
+		@ApiResponse(responseCode = "500", description = "서버 오류가 발생했습니다.",
+			content = @Content(mediaType = "application/json", schema = @Schema(implementation = ResultDto.class)))
+	})
+	ResponseEntity<ResultDto<Boolean>> checkEmailValidate(
+		@Parameter(description = "중복 회원", required = true)
+		MemberDuplicateRequest memberDuplicateRequest
 	);
 
 	@Operation(summary = "회원 로그인", description = "회원 로그인을 수행합니다.")
@@ -45,7 +61,7 @@ public interface AuthApi {
 		@ApiResponse(responseCode = "500", description = "서버 오류가 발생했습니다.",
 			content = @Content(mediaType = "application/json", schema = @Schema(implementation = ResultDto.class)))
 	})
-	ResponseEntity<ResultDto<Void>> memberLogin(
+	ResponseEntity<ResultDto<MemberDetailResponse>> memberLogin(
 		@Parameter(description = "요청 응답", required = true)
 		HttpServletResponse response,
 

--- a/omocha-client/src/main/java/org/auction/client/member/interfaces/AuthApi.java
+++ b/omocha-client/src/main/java/org/auction/client/member/interfaces/AuthApi.java
@@ -5,7 +5,6 @@ import org.auction.client.jwt.UserPrincipal;
 import org.auction.client.member.interfaces.request.MemberCreateRequest;
 import org.auction.client.member.interfaces.request.MemberDuplicateRequest;
 import org.auction.client.member.interfaces.request.MemberLoginRequest;
-import org.auction.client.member.interfaces.response.MemberDetailResponse;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 
@@ -31,7 +30,7 @@ public interface AuthApi {
 		@ApiResponse(responseCode = "500", description = "서버 오류가 발생했습니다.",
 			content = @Content(mediaType = "application/json", schema = @Schema(implementation = ResultDto.class)))
 	})
-	ResponseEntity<ResultDto<MemberDetailResponse>> memberAdd(
+	ResponseEntity<ResultDto<Void>> memberAdd(
 		@Parameter(description = "회원 생성 데이터", required = true)
 		MemberCreateRequest memberCreateRequest
 	);
@@ -61,7 +60,7 @@ public interface AuthApi {
 		@ApiResponse(responseCode = "500", description = "서버 오류가 발생했습니다.",
 			content = @Content(mediaType = "application/json", schema = @Schema(implementation = ResultDto.class)))
 	})
-	ResponseEntity<ResultDto<MemberDetailResponse>> memberLogin(
+	ResponseEntity<ResultDto<Void>> memberLogin(
 		@Parameter(description = "요청 응답", required = true)
 		HttpServletResponse response,
 

--- a/omocha-client/src/main/java/org/auction/client/member/interfaces/AuthController.java
+++ b/omocha-client/src/main/java/org/auction/client/member/interfaces/AuthController.java
@@ -57,7 +57,7 @@ public class AuthController implements AuthApi {
 	@Override
 	@GetMapping("/validate-email")
 	public ResponseEntity<ResultDto<Boolean>> checkEmailValidate(
-		MemberDuplicateRequest memberDuplicateRequest
+		@RequestBody @Valid MemberDuplicateRequest memberDuplicateRequest
 	) {
 		log.debug("Email Duplication Check started");
 		log.info("Received memberDuplicateRequest: {}", memberDuplicateRequest);

--- a/omocha-client/src/main/java/org/auction/client/member/interfaces/AuthController.java
+++ b/omocha-client/src/main/java/org/auction/client/member/interfaces/AuthController.java
@@ -35,7 +35,7 @@ public class AuthController implements AuthApi {
 
 	@Override
 	@PostMapping("/register")
-	public ResponseEntity<ResultDto<MemberDetailResponse>> memberAdd(
+	public ResponseEntity<ResultDto<Void>> memberAdd(
 		@RequestBody @Valid MemberCreateRequest memberCreateRequest
 	) {
 		log.debug("Member register started");
@@ -43,10 +43,9 @@ public class AuthController implements AuthApi {
 
 		MemberDetailResponse responseMember = memberService.addMember(memberCreateRequest);
 
-		ResultDto<MemberDetailResponse> resultDto = ResultDto.res(
+		ResultDto<Void> resultDto = ResultDto.res(
 			MEMBER_CREATE_SUCCESS.getStatusCode(),
-			MEMBER_CREATE_SUCCESS.getResultMsg(),
-			responseMember
+			MEMBER_CREATE_SUCCESS.getResultMsg()
 		);
 
 		return ResponseEntity
@@ -77,7 +76,7 @@ public class AuthController implements AuthApi {
 
 	@Override
 	@PostMapping("/login")
-	public ResponseEntity<ResultDto<MemberDetailResponse>> memberLogin(
+	public ResponseEntity<ResultDto<Void>> memberLogin(
 		HttpServletResponse response,
 		@RequestBody @Valid MemberLoginRequest memberLoginRequest
 	) {
@@ -89,10 +88,9 @@ public class AuthController implements AuthApi {
 		jwtService.generateAccessToken(response, member);
 		jwtService.generateRefreshToken(response, member);
 
-		ResultDto<MemberDetailResponse> resultDto = ResultDto.res(
+		ResultDto<Void> resultDto = ResultDto.res(
 			MEMBER_LOGIN_SUCCESS.getStatusCode(),
-			MEMBER_LOGIN_SUCCESS.getResultMsg(),
-			MemberDetailResponse.toDto(member)
+			MEMBER_LOGIN_SUCCESS.getResultMsg()
 		);
 
 		return ResponseEntity
@@ -112,8 +110,7 @@ public class AuthController implements AuthApi {
 
 		ResultDto<Void> resultDto = ResultDto.res(
 			MEMBER_LOGOUT_SUCCESS.getStatusCode(),
-			MEMBER_LOGOUT_SUCCESS.getResultMsg(),
-			null
+			MEMBER_LOGOUT_SUCCESS.getResultMsg()
 		);
 
 		return ResponseEntity

--- a/omocha-client/src/main/java/org/auction/client/member/interfaces/AuthController.java
+++ b/omocha-client/src/main/java/org/auction/client/member/interfaces/AuthController.java
@@ -7,10 +7,13 @@ import org.auction.client.jwt.UserPrincipal;
 import org.auction.client.jwt.application.JwtService;
 import org.auction.client.member.application.MemberService;
 import org.auction.client.member.interfaces.request.MemberCreateRequest;
+import org.auction.client.member.interfaces.request.MemberDuplicateRequest;
 import org.auction.client.member.interfaces.request.MemberLoginRequest;
+import org.auction.client.member.interfaces.response.MemberDetailResponse;
 import org.auction.domain.member.domain.entity.MemberEntity;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -32,18 +35,39 @@ public class AuthController implements AuthApi {
 
 	@Override
 	@PostMapping("/register")
-	public ResponseEntity<ResultDto<String>> memberAdd(
+	public ResponseEntity<ResultDto<MemberDetailResponse>> memberAdd(
 		@RequestBody @Valid MemberCreateRequest memberCreateRequest
 	) {
-		log.info("Received MemberAddRequest: {}", memberCreateRequest);
 		log.debug("Member register started");
+		log.info("Received MemberAddRequest: {}", memberCreateRequest);
 
-		String response = memberService.addMember(memberCreateRequest);
+		MemberDetailResponse responseMember = memberService.addMember(memberCreateRequest);
 
-		ResultDto<String> resultDto = ResultDto.res(
+		ResultDto<MemberDetailResponse> resultDto = ResultDto.res(
 			MEMBER_CREATE_SUCCESS.getStatusCode(),
 			MEMBER_CREATE_SUCCESS.getResultMsg(),
-			response
+			responseMember
+		);
+
+		return ResponseEntity
+			.status(MEMBER_CREATE_SUCCESS.getHttpStatus())
+			.body(resultDto);
+	}
+
+	@Override
+	@GetMapping("/validate-email")
+	public ResponseEntity<ResultDto<Boolean>> checkEmailValidate(
+		MemberDuplicateRequest memberDuplicateRequest
+	) {
+		log.debug("Email Duplication Check started");
+		log.info("Received memberDuplicateRequest: {}", memberDuplicateRequest);
+
+		boolean duplicate = memberService.isEmailDuplicate(memberDuplicateRequest);
+
+		ResultDto<Boolean> resultDto = ResultDto.res(
+			MEMBER_CREATE_SUCCESS.getStatusCode(),
+			MEMBER_CREATE_SUCCESS.getResultMsg(),
+			duplicate
 		);
 
 		return ResponseEntity
@@ -53,22 +77,22 @@ public class AuthController implements AuthApi {
 
 	@Override
 	@PostMapping("/login")
-	public ResponseEntity<ResultDto<Void>> memberLogin(
+	public ResponseEntity<ResultDto<MemberDetailResponse>> memberLogin(
 		HttpServletResponse response,
 		@RequestBody @Valid MemberLoginRequest memberLoginRequest
 	) {
-		log.info("Received MemberLoginRequest: {}", memberLoginRequest);
 		log.debug("Member login started");
+		log.info("Received MemberLoginRequest: {}", memberLoginRequest);
 
-		MemberEntity requestMember = memberService.findMemberByLoginId(memberLoginRequest);
+		MemberEntity member = memberService.findMember(memberLoginRequest);
 
-		jwtService.generateAccessToken(response, requestMember);
-		jwtService.generateRefreshToken(response, requestMember);
+		jwtService.generateAccessToken(response, member);
+		jwtService.generateRefreshToken(response, member);
 
-		ResultDto<Void> resultDto = ResultDto.res(
+		ResultDto<MemberDetailResponse> resultDto = ResultDto.res(
 			MEMBER_LOGIN_SUCCESS.getStatusCode(),
 			MEMBER_LOGIN_SUCCESS.getResultMsg(),
-			null
+			MemberDetailResponse.toDto(member)
 		);
 
 		return ResponseEntity
@@ -96,4 +120,5 @@ public class AuthController implements AuthApi {
 			.status(MEMBER_LOGOUT_SUCCESS.getHttpStatus())
 			.body(resultDto);
 	}
+
 }

--- a/omocha-client/src/main/java/org/auction/client/member/interfaces/request/MemberCreateRequest.java
+++ b/omocha-client/src/main/java/org/auction/client/member/interfaces/request/MemberCreateRequest.java
@@ -5,7 +5,7 @@ import jakarta.validation.constraints.NotBlank;
 // TODO: 회원가입 로직을 확정하고 수정해야함
 public record MemberCreateRequest(
 	@NotBlank
-	String loginId,
+	String email,
 
 	@NotBlank
 	String password

--- a/omocha-client/src/main/java/org/auction/client/member/interfaces/request/MemberDuplicateRequest.java
+++ b/omocha-client/src/main/java/org/auction/client/member/interfaces/request/MemberDuplicateRequest.java
@@ -2,11 +2,8 @@ package org.auction.client.member.interfaces.request;
 
 import jakarta.validation.constraints.NotBlank;
 
-public record MemberLoginRequest(
+public record MemberDuplicateRequest(
 	@NotBlank
-	String email,
-
-	@NotBlank
-	String password
+	String email
 ) {
 }

--- a/omocha-client/src/main/java/org/auction/client/member/interfaces/response/MemberDetailResponse.java
+++ b/omocha-client/src/main/java/org/auction/client/member/interfaces/response/MemberDetailResponse.java
@@ -3,25 +3,22 @@ package org.auction.client.member.interfaces.response;
 import org.auction.domain.member.domain.entity.MemberEntity;
 import org.auction.domain.member.domain.enums.Role;
 
-public record MemberGetResponse(
-	String loginId,
-	String password,
+// TODO: 넘겨줄 정보들에 대해 추후 정해야함, 일단은 Password 제외하고 다 넘겨줌
+public record MemberDetailResponse(
+	String email,
 	String nickname,
 	String birth,
-	String email,
 	String phoenNumber,
 	String imageUrl,
 	Role role
 ) {
-	public static MemberGetResponse toDto(
+	public static MemberDetailResponse toDto(
 		MemberEntity memberEntity
 	) {
-		return new MemberGetResponse(
-			memberEntity.getLoginId(),
-			memberEntity.getPassword(),
+		return new MemberDetailResponse(
+			memberEntity.getEmail(),
 			memberEntity.getNickname(),
 			memberEntity.getBirth(),
-			memberEntity.getEmail(),
 			memberEntity.getPhoneNumber(),
 			memberEntity.getProfileImageUrl(),
 			memberEntity.getRole()

--- a/omocha-client/src/main/java/org/auction/client/member/interfaces/response/MemberDetailResponse.java
+++ b/omocha-client/src/main/java/org/auction/client/member/interfaces/response/MemberDetailResponse.java
@@ -8,7 +8,7 @@ public record MemberDetailResponse(
 	String email,
 	String nickname,
 	String birth,
-	String phoenNumber,
+	String phoneNumber,
 	String imageUrl,
 	Role role
 ) {

--- a/omocha-client/src/main/java/org/auction/client/mypage/interfaces/response/MemberInfoResponse.java
+++ b/omocha-client/src/main/java/org/auction/client/mypage/interfaces/response/MemberInfoResponse.java
@@ -5,14 +5,14 @@ import org.auction.domain.member.domain.entity.MemberEntity;
 public record MemberInfoResponse(
 	// TODO : 회원 가입 정보 추가 후 변경
 	Long memberId,
-	String loginId
+	String email
 ) {
 	public static MemberInfoResponse toDto(
 		MemberEntity memberEntity
 	) {
 		return new MemberInfoResponse(
 			memberEntity.getMemberId(),
-			memberEntity.getLoginId()
+			memberEntity.getEmail()
 		);
 
 	}

--- a/omocha-domain/src/main/java/org/auction/domain/member/domain/entity/MemberEntity.java
+++ b/omocha-domain/src/main/java/org/auction/domain/member/domain/entity/MemberEntity.java
@@ -28,8 +28,8 @@ public class MemberEntity extends TimeTrackableEntity {
 	@Column(name = "member_id")
 	private Long memberId;
 
-	@Column(name = "login_id")
-	private String loginId;
+	@Column(name = "email")
+	private String email;
 
 	// TODO: Password VO로 변경해야함
 	@Column(name = "password")
@@ -43,9 +43,6 @@ public class MemberEntity extends TimeTrackableEntity {
 
 	@Column(name = "birth")
 	private String birth;
-
-	@Column(name = "email")
-	private String email;
 
 	@Column(name = "phone_number")
 	private String phoneNumber;
@@ -70,12 +67,11 @@ public class MemberEntity extends TimeTrackableEntity {
 
 	@Builder
 	public MemberEntity(
-		String loginId, String password, String nickname,
-		String username, String birth, String email,
-		String phoneNumber, String profileImageUrl, Role role,
-		String provider, String providerId, UserStatus userStatus
+		String email, String password, String nickname,
+		String username, String birth, String phoneNumber,
+		String profileImageUrl, Role role, String provider,
+		String providerId, UserStatus userStatus
 	) {
-		this.loginId = loginId;
 		this.password = password;
 		this.nickname = nickname;
 		this.username = username;

--- a/omocha-domain/src/main/java/org/auction/domain/member/infrastructure/MemberRepository.java
+++ b/omocha-domain/src/main/java/org/auction/domain/member/infrastructure/MemberRepository.java
@@ -7,9 +7,11 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface MemberRepository extends JpaRepository<MemberEntity, Long> {
 
-	boolean existsByLoginId(String loginId);
+	boolean existsByEmail(String email);
 
-	Optional<MemberEntity> findByLoginId(String loginId);
+	Optional<MemberEntity> findByEmail(String email);
 
 	Optional<MemberEntity> findByProviderAndProviderId(String provider, String providerId);
+
+	boolean existsByEmailAndProviderIsNull(String email);
 }


### PR DESCRIPTION
## What is this PR? 🔍

- 기능 : 아이디 중복체크 API 추가 및 회원 컬럼 수정
- issue : #101 #102 

## Changes 📝
- login_id 컬럼 삭제 및 email로 로그인 처리
- 아이디 중복체크 API 추가
- Dockerfile에 TimeZone Asia/Seoul 설정
- JwtService 불필요한 메서드 제거

## Precaution
- 로그인 및 회원가입의 Response Body에 member의 정보를 담지 않도록 수정하였습니다.
  - JWT를 사용하기 때문에 유저 정보 넘겨주지 않음

## ✔️ Please check if the PR fulfills these requirements

- [ ] It's submitted to the correct branch, not the `develop` branch unconditionally?
- [ ] If on a hotfix branch, ensure it targets `main`?
- [ ] There are no warning message when you run `yarn lint`

- Close #101 
- Close #102 
