### PR TITLE
[FEAT] Cursor Pagination 및 정렬 순서 수정

### DIFF
--- a/omocha-client/src/main/java/org/auction/client/bid/application/ConcludeService.java
+++ b/omocha-client/src/main/java/org/auction/client/bid/application/ConcludeService.java
@@ -38,6 +38,7 @@ public class ConcludeService {
 		AuctionEntity auction
 	) {
 		if (auction.getEndDate().isBefore(LocalDateTime.now())) {
+			// TODO : DB에서 바로 꺼내오도록 변경
 			Optional<BidEntity> optionalHighestBid = bidService.getCurrentHighestBid(auction);
 
 			optionalHighestBid.ifPresentOrElse(highestBid -> {
@@ -45,7 +46,6 @@ public class ConcludeService {
 
 				createAuctionConclude(auction, highestBid);
 
-				// TODO: 채팅방 테스트 이후 highestBid를 매개변수로 넘겨주도록 처리
 				MemberEntity highestBuyer = highestBid.getBuyerEntity();
 				chatRoomService.addChatRoom(highestBuyer, auction.getAuctionId(), highestBid.getBidPrice());
 			}, () -> {

--- a/omocha-client/src/main/java/org/auction/client/bid/application/ConcludeService.java
+++ b/omocha-client/src/main/java/org/auction/client/bid/application/ConcludeService.java
@@ -47,7 +47,7 @@ public class ConcludeService {
 
 				// TODO: 채팅방 테스트 이후 highestBid를 매개변수로 넘겨주도록 처리
 				MemberEntity highestBuyer = highestBid.getBuyerEntity();
-				chatRoomService.addChatRoom(highestBuyer, auction.getAuctionId());
+				chatRoomService.addChatRoom(highestBuyer, auction.getAuctionId(), highestBid.getBidPrice());
 			}, () -> {
 				auctionService.modifyAuctionStatus(auction, AuctionStatus.NO_BIDS);
 			});

--- a/omocha-client/src/main/java/org/auction/client/chat/application/ChatRoomService.java
+++ b/omocha-client/src/main/java/org/auction/client/chat/application/ChatRoomService.java
@@ -31,7 +31,6 @@ public class ChatRoomService {
 	private final BidService bidService;
 
 	// TODO: 채팅 테스트 완료되면 로직 변경 필요
-	//       concludePrice 매개변수로 받도록, 판매자 구매자 동일한지 검증 제외
 	@Transactional
 	public void addChatRoom(
 		MemberEntity buyer,

--- a/omocha-client/src/main/java/org/auction/client/chat/application/ChatRoomService.java
+++ b/omocha-client/src/main/java/org/auction/client/chat/application/ChatRoomService.java
@@ -31,6 +31,7 @@ public class ChatRoomService {
 	private final BidService bidService;
 
 	// TODO: 채팅 테스트 완료되면 로직 변경 필요
+	//       concludePrice 매개변수로 받도록, 판매자 구매자 동일한지 검증 제외
 	@Transactional
 	public void addChatRoom(
 		MemberEntity buyer,

--- a/omocha-client/src/main/java/org/auction/client/chat/application/ChatRoomService.java
+++ b/omocha-client/src/main/java/org/auction/client/chat/application/ChatRoomService.java
@@ -1,14 +1,10 @@
 package org.auction.client.chat.application;
 
 import static org.auction.client.common.code.AuctionCode.*;
-import static org.auction.client.common.code.BidCode.*;
 import static org.auction.client.common.code.ChatCode.*;
 
-import org.auction.client.bid.application.BidService;
 import org.auction.client.exception.auction.AuctionNotFoundException;
-import org.auction.client.exception.bid.NoBidsException;
 import org.auction.client.exception.chat.ChatRoomAlreadyExistsException;
-import org.auction.client.exception.chat.SellerIsBuyerException;
 import org.auction.domain.auction.domain.entity.AuctionEntity;
 import org.auction.domain.auction.infrastructure.AuctionRepository;
 import org.auction.domain.chat.domain.dto.ChatRoomInfoDto;
@@ -28,32 +24,19 @@ public class ChatRoomService {
 
 	private final ChatRoomRepository roomRepository;
 	private final AuctionRepository auctionRepository;
-	private final BidService bidService;
 
 	// TODO: 채팅 테스트 완료되면 로직 변경 필요
 	//       concludePrice 매개변수로 받도록, 판매자 구매자 동일한지 검증 제외
 	@Transactional
 	public void addChatRoom(
 		MemberEntity buyer,
-		Long auctionId
+		Long auctionId,
+		Long concludePrice
 	) {
 		AuctionEntity auctionEntity = auctionRepository.findById(auctionId)
 			.orElseThrow(() -> new AuctionNotFoundException(AUCTION_NOT_FOUND));
 
 		MemberEntity seller = auctionEntity.getMemberEntity();
-
-		// TODO: 추후 삭제 예정
-		if (seller.getMemberId() == buyer.getMemberId()) {
-			throw new SellerIsBuyerException(SELLER_IS_BUYER);
-		}
-
-		// TODO: 추후 삭제 예정
-		Long concludePrice = bidService.getCurrentHighestBidPrice(auctionEntity);
-
-		// TODO: 추후 삭제 예정
-		if (concludePrice == null) {
-			throw new NoBidsException(NO_BIDS_FOUND);
-		}
 
 		if (roomRepository.existsByAuctionId(auctionId)) {
 			throw new ChatRoomAlreadyExistsException(CHATROOM_ALREADY_EXISTS);

--- a/omocha-client/src/main/java/org/auction/client/chat/application/ChatRoomService.java
+++ b/omocha-client/src/main/java/org/auction/client/chat/application/ChatRoomService.java
@@ -5,13 +5,13 @@ import static org.auction.client.common.code.BidCode.*;
 import static org.auction.client.common.code.ChatCode.*;
 
 import org.auction.client.bid.application.BidService;
-import org.auction.client.chat.interfaces.response.ChatRoomInfoDto;
 import org.auction.client.exception.auction.AuctionNotFoundException;
 import org.auction.client.exception.bid.NoBidsException;
 import org.auction.client.exception.chat.ChatRoomAlreadyExistsException;
 import org.auction.client.exception.chat.SellerIsBuyerException;
 import org.auction.domain.auction.domain.entity.AuctionEntity;
 import org.auction.domain.auction.infrastructure.AuctionRepository;
+import org.auction.domain.chat.domain.dto.ChatRoomInfoDto;
 import org.auction.domain.chat.domain.entity.ChatRoomEntity;
 import org.auction.domain.chat.infrastructure.ChatRoomRepository;
 import org.auction.domain.member.domain.entity.MemberEntity;
@@ -33,7 +33,7 @@ public class ChatRoomService {
 	// TODO: 채팅 테스트 완료되면 로직 변경 필요
 	//       concludePrice 매개변수로 받도록, 판매자 구매자 동일한지 검증 제외
 	@Transactional
-	public ChatRoomInfoDto addChatRoom(
+	public void addChatRoom(
 		MemberEntity buyer,
 		Long auctionId
 	) {
@@ -67,8 +67,6 @@ public class ChatRoomService {
 			.auctionId(auctionId)
 			.build();
 		roomRepository.save(chatRoom);
-
-		return ChatRoomInfoDto.toDto(chatRoom);
 	}
 
 	@Transactional(readOnly = true)
@@ -76,8 +74,7 @@ public class ChatRoomService {
 		MemberEntity memberEntity,
 		Pageable pageable
 	) {
-		return roomRepository.findChatRoomsByUser(memberEntity, pageable)
-			.map(ChatRoomInfoDto::toDto);
+		return roomRepository.findChatRoomsByUser(memberEntity, pageable);
 	}
 
 }

--- a/omocha-client/src/main/java/org/auction/client/chat/application/ChatService.java
+++ b/omocha-client/src/main/java/org/auction/client/chat/application/ChatService.java
@@ -2,6 +2,8 @@ package org.auction.client.chat.application;
 
 import static org.auction.client.common.code.ChatCode.*;
 
+import java.time.LocalDateTime;
+
 import org.auction.client.chat.interfaces.response.ChatMessageResponse;
 import org.auction.client.chat.interfaces.response.ChatRoomDetailsResponse;
 import org.auction.client.exception.chat.ChatRoomAccessException;
@@ -51,6 +53,7 @@ public class ChatService {
 	public ChatRoomDetailsResponse findChatRoomMessages(
 		Long roomId,
 		MemberEntity memberEntity,
+		LocalDateTime cursor,
 		Pageable pageable
 	) {
 		// 채팅방 조회
@@ -62,8 +65,9 @@ public class ChatService {
 			throw new ChatRoomAccessException(CHATROOM_ACCESS_UNAUTHORIZED);
 		}
 
-		Slice<ChatMessageResponse> messages = chatRepository.findChatMessagesByRoomId(roomId, pageable)
-			.map(ChatMessageResponse::toDto);
+		Slice<ChatMessageResponse> messages = chatRepository.findChatMessagesByRoomId(
+			roomId, cursor, pageable
+		).map(ChatMessageResponse::toDto);
 
 		return ChatRoomDetailsResponse.toDto(roomEntity, messages);
 	}

--- a/omocha-client/src/main/java/org/auction/client/chat/interfaces/ChatRoomApi.java
+++ b/omocha-client/src/main/java/org/auction/client/chat/interfaces/ChatRoomApi.java
@@ -29,7 +29,7 @@ public interface ChatRoomApi {
 
 	@Operation(
 		summary = "채팅방 생성(Front 테스트용)",
-		description = "특정 경매에 대한 새로운 채팅방을 생성합니다."
+		description = "특정 경매에 대한 새로운 채팅방은 스케줄러로 동작합니다"
 	)
 	@ApiResponses(value = {
 		@ApiResponse(

--- a/omocha-client/src/main/java/org/auction/client/chat/interfaces/ChatRoomApi.java
+++ b/omocha-client/src/main/java/org/auction/client/chat/interfaces/ChatRoomApi.java
@@ -28,7 +28,7 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 public interface ChatRoomApi {
 
 	@Operation(
-		summary = "채팅방 생성",
+		summary = "채팅방 생성(Front 테스트용)",
 		description = "특정 경매에 대한 새로운 채팅방을 생성합니다."
 	)
 	@ApiResponses(value = {

--- a/omocha-client/src/main/java/org/auction/client/chat/interfaces/ChatRoomApi.java
+++ b/omocha-client/src/main/java/org/auction/client/chat/interfaces/ChatRoomApi.java
@@ -1,15 +1,19 @@
 package org.auction.client.chat.interfaces;
 
+import java.time.LocalDateTime;
+
 import org.auction.client.chat.interfaces.response.ChatRoomDetailsResponse;
-import org.auction.client.chat.interfaces.response.ChatRoomInfoDto;
 import org.auction.client.common.dto.ResultDto;
 import org.auction.client.common.dto.SliceResponse;
 import org.auction.client.jwt.UserPrincipal;
+import org.auction.domain.chat.domain.dto.ChatRoomInfoDto;
+import org.springdoc.core.annotations.ParameterObject;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.web.PageableDefault;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestParam;
 
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
@@ -64,7 +68,7 @@ public interface ChatRoomApi {
 			)
 		)
 	})
-	ResponseEntity<ResultDto<ChatRoomInfoDto>> chatRoomSave(
+	ResponseEntity<ResultDto<Void>> chatRoomSave(
 		@Parameter(
 			description = "경매 ID",
 			required = true,
@@ -138,12 +142,11 @@ public interface ChatRoomApi {
 		)
 		@AuthenticationPrincipal UserPrincipal userPrincipal,
 
-		@Parameter(
-			description = "페이징 정보 (예: 페이지 번호와 크기)",
-			required = false,
-			in = ParameterIn.QUERY
-		)
-		Pageable pageable
+		@RequestParam(required = false)
+		LocalDateTime cursor,
+
+		@ParameterObject
+		@PageableDefault(size = 10) Pageable pageable
 	);
 
 	@Operation(
@@ -173,7 +176,7 @@ public interface ChatRoomApi {
 			)
 		)
 	})
-	ResponseEntity<ResultDto<SliceResponse>> chatRoomsLists(
+	ResponseEntity<ResultDto<SliceResponse<ChatRoomInfoDto>>> chatRoomsLists(
 		@Parameter(
 			description = "인증된 사용자 정보",
 			required = true,
@@ -181,11 +184,7 @@ public interface ChatRoomApi {
 		)
 		@AuthenticationPrincipal UserPrincipal userPrincipal,
 
-		@Parameter(
-			description = "페이지 번호와 페이지 크기",
-			example = "0",
-			in = ParameterIn.QUERY
-		)
+		@ParameterObject
 		@PageableDefault(page = 0, size = 10) Pageable pageable
 	);
 }

--- a/omocha-client/src/main/java/org/auction/client/chat/interfaces/ChatRoomController.java
+++ b/omocha-client/src/main/java/org/auction/client/chat/interfaces/ChatRoomController.java
@@ -61,6 +61,7 @@ public class ChatRoomController implements ChatRoomApi {
 		@PathVariable Long roomId,
 		@AuthenticationPrincipal
 		UserPrincipal userPrincipal,
+		// TODO : parameter 로 오면 지저분해서 나중에 Header 혹은 Encoding을 해야함
 		@RequestParam(required = false)
 		LocalDateTime cursor,
 		@PageableDefault(size = 10)

--- a/omocha-client/src/main/java/org/auction/client/chat/interfaces/ChatRoomController.java
+++ b/omocha-client/src/main/java/org/auction/client/chat/interfaces/ChatRoomController.java
@@ -36,19 +36,14 @@ public class ChatRoomController implements ChatRoomApi {
 	private final ChatService chatService;
 
 	// EXPLAIN : 채팅방 생성
-	// TODO : 낙찰이 되면 바로 채팅방 생성 로직으로 변경
 	@Override
 	@PostMapping("/{auctionId}")
 	public ResponseEntity<ResultDto<Void>> chatRoomSave(
 		@PathVariable Long auctionId,
 		@AuthenticationPrincipal UserPrincipal userPrincipal) {
 
-		// TODO : UserPrincipal 이 유효한 값인지 확인하는 로직 추가 필요
-
-		// 채팅방 생성
 		chatRoomService.addChatRoom(userPrincipal.getMemberEntity(), auctionId);
 
-		// 응답 생성
 		ResultDto<Void> resultDto = ResultDto.res(
 			CHATROOM_CREATE_SUCCESS.getStatusCode(),
 			CHATROOM_CREATE_SUCCESS.getResultMsg()
@@ -73,7 +68,6 @@ public class ChatRoomController implements ChatRoomApi {
 	) {
 		log.info("Fetching chat room messages for room ID: {}", roomId);
 
-		// 채팅방과 메시지 목록 조회
 		ChatRoomDetailsResponse response = chatService.findChatRoomMessages(
 			roomId,
 			userPrincipal.getMemberEntity(),
@@ -81,7 +75,6 @@ public class ChatRoomController implements ChatRoomApi {
 			pageable
 		);
 
-		// 응답 생성
 		ResultDto<ChatRoomDetailsResponse> resultDto = ResultDto.res(
 			CHATROOM_DETAILS_AND_MESSAGES_SUCCESS.getStatusCode(),
 			CHATROOM_DETAILS_AND_MESSAGES_SUCCESS.getResultMsg(),

--- a/omocha-client/src/main/java/org/auction/client/chat/interfaces/ChatRoomController.java
+++ b/omocha-client/src/main/java/org/auction/client/chat/interfaces/ChatRoomController.java
@@ -35,7 +35,7 @@ public class ChatRoomController implements ChatRoomApi {
 	private final ChatRoomService chatRoomService;
 	private final ChatService chatService;
 
-	// EXPLAIN : 채팅방 생성
+	// EXPLAIN : 채팅방 생성 (Front 테스트용)
 	@Override
 	@PostMapping("/{auctionId}")
 	public ResponseEntity<ResultDto<Void>> chatRoomSave(

--- a/omocha-client/src/main/java/org/auction/client/chat/interfaces/response/ChatRoomDetailsResponse.java
+++ b/omocha-client/src/main/java/org/auction/client/chat/interfaces/response/ChatRoomDetailsResponse.java
@@ -1,7 +1,5 @@
 package org.auction.client.chat.interfaces.response;
 
-import java.time.LocalDateTime;
-
 import org.auction.client.common.dto.SliceResponse;
 import org.auction.domain.chat.domain.dto.ChatRoomInfoDto;
 import org.auction.domain.chat.domain.entity.ChatRoomEntity;
@@ -15,18 +13,10 @@ public record ChatRoomDetailsResponse(
 		ChatRoomEntity chatRoomEntity,
 		Slice<ChatMessageResponse> messages
 	) {
-		LocalDateTime lastMessageTime;
-
-		if (messages != null && !messages.isEmpty()) {
-			// 메시지가 있을 경우, 가장 최신 메시지의 시간을 가져옴
-			lastMessageTime = messages.getContent().get(0).createdDate();
-		} else {
-			// 메시지가 없을 경우, 채팅방 생성 시간을 사용
-			lastMessageTime = chatRoomEntity.getCreatedAt();
-		}
 
 		return new ChatRoomDetailsResponse(
-			ChatRoomInfoDto.toDto(chatRoomEntity, lastMessageTime),
+			// TODO : 추후 refactoring 필요
+			ChatRoomInfoDto.toDto(chatRoomEntity, null),
 			new SliceResponse<>(messages)
 		);
 	}

--- a/omocha-client/src/main/java/org/auction/client/chat/interfaces/response/ChatRoomDetailsResponse.java
+++ b/omocha-client/src/main/java/org/auction/client/chat/interfaces/response/ChatRoomDetailsResponse.java
@@ -1,6 +1,9 @@
 package org.auction.client.chat.interfaces.response;
 
+import java.time.LocalDateTime;
+
 import org.auction.client.common.dto.SliceResponse;
+import org.auction.domain.chat.domain.dto.ChatRoomInfoDto;
 import org.auction.domain.chat.domain.entity.ChatRoomEntity;
 import org.springframework.data.domain.Slice;
 
@@ -12,8 +15,18 @@ public record ChatRoomDetailsResponse(
 		ChatRoomEntity chatRoomEntity,
 		Slice<ChatMessageResponse> messages
 	) {
+		LocalDateTime lastMessageTime;
+
+		if (messages != null && !messages.isEmpty()) {
+			// 메시지가 있을 경우, 가장 최신 메시지의 시간을 가져옴
+			lastMessageTime = messages.getContent().get(0).createdDate();
+		} else {
+			// 메시지가 없을 경우, 채팅방 생성 시간을 사용
+			lastMessageTime = chatRoomEntity.getCreatedAt();
+		}
+
 		return new ChatRoomDetailsResponse(
-			ChatRoomInfoDto.toDto(chatRoomEntity),
+			ChatRoomInfoDto.toDto(chatRoomEntity, lastMessageTime),
 			new SliceResponse<>(messages)
 		);
 	}

--- a/omocha-client/src/main/java/org/auction/client/chat/interfaces/response/ChatRoomListResponse.java
+++ b/omocha-client/src/main/java/org/auction/client/chat/interfaces/response/ChatRoomListResponse.java
@@ -2,6 +2,8 @@ package org.auction.client.chat.interfaces.response;
 
 import java.util.List;
 
+import org.auction.domain.chat.domain.dto.ChatRoomInfoDto;
+
 public record ChatRoomListResponse(
 	List<ChatRoomInfoDto> chatRooms
 ) {

--- a/omocha-client/src/main/java/org/auction/client/config/security/SecurityConfig.java
+++ b/omocha-client/src/main/java/org/auction/client/config/security/SecurityConfig.java
@@ -42,7 +42,7 @@ public class SecurityConfig {
 		"/sub/**",
 		"/pub/**",
 		"/{roomId}/messages",
-		"/omocha-websocket"
+		"/omocha-websocket/"
 	};
 
 	@Bean

--- a/omocha-domain/src/main/java/org/auction/domain/chat/domain/dto/ChatRoomInfoDto.java
+++ b/omocha-domain/src/main/java/org/auction/domain/chat/domain/dto/ChatRoomInfoDto.java
@@ -5,6 +5,7 @@ import java.time.LocalDateTime;
 import org.auction.domain.chat.domain.entity.ChatRoomEntity;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
+import com.querydsl.core.annotations.QueryProjection;
 
 public record ChatRoomInfoDto(
 	Long auctionId, // 경매 ID
@@ -20,7 +21,36 @@ public record ChatRoomInfoDto(
 	@JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd HH:mm:ss")
 	LocalDateTime lastMessageTime
 ) {
-	public static ChatRoomInfoDto toDto(ChatRoomEntity chatRoomEntity, LocalDateTime lastMessageTime) {
+
+	@QueryProjection
+	public ChatRoomInfoDto(
+		Long auctionId, // 경매 ID
+		Long roomId,    // 채팅방 ID
+		String roomName, // 경매 TITLE
+		Long sellerId,   // 판매자 ID
+		String sellerName, // 판매자 NAME
+		Long concludePrice,
+		Long buyerId,    // 구매자 ID
+		String buyerName,
+		LocalDateTime createdDate,
+		LocalDateTime lastMessageTime
+	) {
+		this.auctionId = auctionId;
+		this.roomId = roomId;
+		this.roomName = roomName;
+		this.sellerId = sellerId;
+		this.sellerName = sellerName;
+		this.concludePrice = concludePrice;
+		this.buyerId = buyerId;
+		this.buyerName = buyerName;
+		this.createdDate = createdDate;
+		this.lastMessageTime = lastMessageTime;
+	}
+
+	public static ChatRoomInfoDto toDto(
+		ChatRoomEntity chatRoomEntity,
+		LocalDateTime lastMessageTime
+	) {
 		return new ChatRoomInfoDto(
 			chatRoomEntity.getAuctionId(),
 			chatRoomEntity.getChatRoomId(),

--- a/omocha-domain/src/main/java/org/auction/domain/chat/domain/dto/ChatRoomInfoDto.java
+++ b/omocha-domain/src/main/java/org/auction/domain/chat/domain/dto/ChatRoomInfoDto.java
@@ -1,4 +1,4 @@
-package org.auction.client.chat.interfaces.response;
+package org.auction.domain.chat.domain.dto;
 
 import java.time.LocalDateTime;
 
@@ -8,18 +8,19 @@ import com.fasterxml.jackson.annotation.JsonFormat;
 
 public record ChatRoomInfoDto(
 	Long auctionId, // 경매 ID
-	Long roomId, // 채팅방 ID
+	Long roomId,    // 채팅방 ID
 	String roomName, // 경매 TITLE
-	Long sellerId, // 판매자 ID
+	Long sellerId,   // 판매자 ID
 	String sellerName, // 판매자 NAME
 	Long concludePrice,
-	Long buyerId, // 구매자 ID
+	Long buyerId,    // 구매자 ID
 	String buyerName,
 	@JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd HH:mm:ss")
-	LocalDateTime createdDate
+	LocalDateTime createdDate,
+	@JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd HH:mm:ss")
+	LocalDateTime lastMessageTime
 ) {
-
-	public static ChatRoomInfoDto toDto(ChatRoomEntity chatRoomEntity) {
+	public static ChatRoomInfoDto toDto(ChatRoomEntity chatRoomEntity, LocalDateTime lastMessageTime) {
 		return new ChatRoomInfoDto(
 			chatRoomEntity.getAuctionId(),
 			chatRoomEntity.getChatRoomId(),
@@ -29,8 +30,8 @@ public record ChatRoomInfoDto(
 			chatRoomEntity.getConcludePrice(),
 			chatRoomEntity.getBuyer().getMemberId(),
 			chatRoomEntity.getBuyer().getNickname(),
-			chatRoomEntity.getCreatedAt()
+			chatRoomEntity.getCreatedAt(),
+			lastMessageTime
 		);
 	}
-
 }

--- a/omocha-domain/src/main/java/org/auction/domain/chat/infrastructure/custom/ChatRepositoryCustom.java
+++ b/omocha-domain/src/main/java/org/auction/domain/chat/infrastructure/custom/ChatRepositoryCustom.java
@@ -1,5 +1,7 @@
 package org.auction.domain.chat.infrastructure.custom;
 
+import java.time.LocalDateTime;
+
 import org.auction.domain.chat.domain.entity.ChatEntity;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
@@ -8,6 +10,7 @@ public interface ChatRepositoryCustom {
 
 	Slice<ChatEntity> findChatMessagesByRoomId(
 		Long roomId,
+		LocalDateTime cursor,
 		Pageable pageable
 	);
 }

--- a/omocha-domain/src/main/java/org/auction/domain/chat/infrastructure/custom/ChatRoomRepositoryCustom.java
+++ b/omocha-domain/src/main/java/org/auction/domain/chat/infrastructure/custom/ChatRoomRepositoryCustom.java
@@ -1,11 +1,11 @@
 package org.auction.domain.chat.infrastructure.custom;
 
-import org.auction.domain.chat.domain.entity.ChatRoomEntity;
+import org.auction.domain.chat.domain.dto.ChatRoomInfoDto;
 import org.auction.domain.member.domain.entity.MemberEntity;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 
 public interface ChatRoomRepositoryCustom {
 
-	Slice<ChatRoomEntity> findChatRoomsByUser(MemberEntity memberEntity, Pageable pageable);
+	Slice<ChatRoomInfoDto> findChatRoomsByUser(MemberEntity memberEntity, Pageable pageable);
 }

--- a/omocha-domain/src/main/java/org/auction/domain/chat/infrastructure/custom/ChatRoomRepositoryImpl.java
+++ b/omocha-domain/src/main/java/org/auction/domain/chat/infrastructure/custom/ChatRoomRepositoryImpl.java
@@ -4,6 +4,7 @@ import java.time.LocalDateTime;
 import java.util.List;
 
 import org.auction.domain.chat.domain.dto.ChatRoomInfoDto;
+import org.auction.domain.chat.domain.dto.QChatRoomInfoDto;
 import org.auction.domain.chat.domain.entity.QChatEntity;
 import org.auction.domain.chat.domain.entity.QChatRoomEntity;
 import org.auction.domain.member.domain.entity.MemberEntity;
@@ -12,7 +13,6 @@ import org.springframework.data.domain.Slice;
 import org.springframework.data.domain.SliceImpl;
 
 import com.querydsl.core.types.Expression;
-import com.querydsl.core.types.Projections;
 import com.querydsl.core.types.dsl.DateTimeExpression;
 import com.querydsl.core.types.dsl.Expressions;
 import com.querydsl.jpa.JPAExpressions;
@@ -50,8 +50,7 @@ public class ChatRoomRepositoryImpl implements ChatRoomRepositoryCustom {
 			lastMessageTimeOrder.coalesce(chatRoom.createdAt);
 
 		List<ChatRoomInfoDto> chatRooms = queryFactory
-			.select(Projections.constructor(
-				ChatRoomInfoDto.class,
+			.select(new QChatRoomInfoDto(
 				chatRoom.auctionId,
 				chatRoom.chatRoomId,
 				chatRoom.roomName,

--- a/omocha-domain/src/main/java/org/auction/domain/chat/infrastructure/custom/ChatRoomRepositoryImpl.java
+++ b/omocha-domain/src/main/java/org/auction/domain/chat/infrastructure/custom/ChatRoomRepositoryImpl.java
@@ -1,16 +1,21 @@
 package org.auction.domain.chat.infrastructure.custom;
 
-import static org.auction.domain.chat.domain.entity.QChatEntity.*;
-import static org.auction.domain.chat.domain.entity.QChatRoomEntity.*;
-
+import java.time.LocalDateTime;
 import java.util.List;
 
-import org.auction.domain.chat.domain.entity.ChatRoomEntity;
+import org.auction.domain.chat.domain.dto.ChatRoomInfoDto;
+import org.auction.domain.chat.domain.entity.QChatEntity;
+import org.auction.domain.chat.domain.entity.QChatRoomEntity;
 import org.auction.domain.member.domain.entity.MemberEntity;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 import org.springframework.data.domain.SliceImpl;
 
+import com.querydsl.core.types.Expression;
+import com.querydsl.core.types.Projections;
+import com.querydsl.core.types.dsl.DateTimeExpression;
+import com.querydsl.core.types.dsl.Expressions;
+import com.querydsl.jpa.JPAExpressions;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 
 import jakarta.persistence.EntityManager;
@@ -25,32 +30,52 @@ public class ChatRoomRepositoryImpl implements ChatRoomRepositoryCustom {
 	}
 
 	@Override
-	public Slice<ChatRoomEntity> findChatRoomsByUser(
+	public Slice<ChatRoomInfoDto> findChatRoomsByUser(
 		MemberEntity memberEntity,
 		Pageable pageable
 	) {
-		List<ChatRoomEntity> chatRooms = queryFactory
-			.select(chatRoomEntity)
-			.from(chatRoomEntity)
-			.leftJoin(chatEntity)
-			.on(chatEntity.chatRoom.eq(chatRoomEntity))
-			.where(chatRoomEntity.buyer.eq(memberEntity)
-				.or(chatRoomEntity.seller.eq(memberEntity)))
-			.orderBy(chatEntity.createdAt.max().desc())
-			.groupBy(chatRoomEntity.chatRoomId)
+		QChatRoomEntity chatRoom = QChatRoomEntity.chatRoomEntity;
+		QChatEntity chatSub = QChatEntity.chatEntity;
+
+		Expression<LocalDateTime> lastMessagetime = JPAExpressions
+			.select(chatSub.createdAt.max())
+			.from(chatSub)
+			.where(chatSub.chatRoom.eq(chatRoom));
+
+		DateTimeExpression<LocalDateTime> lastMessageTimeOrder =
+			Expressions.asDateTime(lastMessagetime);
+
+		// 최신 메시지 또는 생성 시간이 최근이 채팅방이 상단에 표시
+		DateTimeExpression<LocalDateTime> orderTime =
+			lastMessageTimeOrder.coalesce(chatRoom.createdAt);
+
+		List<ChatRoomInfoDto> chatRooms = queryFactory
+			.select(Projections.constructor(
+				ChatRoomInfoDto.class,
+				chatRoom.auctionId,
+				chatRoom.chatRoomId,
+				chatRoom.roomName,
+				chatRoom.seller.memberId,
+				chatRoom.seller.nickname,
+				chatRoom.concludePrice,
+				chatRoom.buyer.memberId,
+				chatRoom.buyer.nickname,
+				chatRoom.createdAt,
+				lastMessagetime
+			))
+			.from(chatRoom)
+			.where(chatRoom.buyer.eq(memberEntity)
+				.or(chatRoom.seller.eq(memberEntity)))
+			.orderBy(orderTime.desc())
 			.offset(pageable.getOffset())
 			.limit(pageable.getPageSize() + 1)
 			.fetch();
 
-		return new SliceImpl<>(chatRooms, pageable, hasNextPage(chatRooms, pageable.getPageSize()));
-
-	}
-
-	private boolean hasNextPage(List<ChatRoomEntity> chatRooms, int pageSize) {
-		if (chatRooms.size() > pageSize) {
-			chatRooms.remove(pageSize);
-			return true;
+		boolean hasNext = chatRooms.size() > pageable.getPageSize();
+		if (hasNext) {
+			chatRooms.remove(pageable.getPageSize());
 		}
-		return false;
+
+		return new SliceImpl<>(chatRooms, pageable, hasNext);
 	}
 }


### PR DESCRIPTION
## What is this PR? 🔍

- 기능 : Cursor Pagination 및 정렬
- issue : #106 

## Changes 📝

## **Cursor 기반 페이징 구현**

- **커서 사용**: `LocalDateTime cursor`를 사용하여 해당 시간 이전의 메시지를 조회  
- **커서가 없는 경우**: 최신 메시지부터 시작하여 조회  


## 채팅 메시지 정렬 구현

채팅 메시지 정렬 방식은 **최신 메시지**가 상단에 표시되도록 하고, 메시지가 없는 경우에는 **채팅방 생성 시간**을 기준으로 정렬

#### 정렬 기준 쿼리
```java
.orderBy(lastMessageTime.desc().nullsLast(), chatRoom.createdAt.desc())
```
- `lastMessageTime.desc()`: 메시지가 존재하는 채팅방은 가장 최근 메시지 시간을 기준으로 내림차순 정렬
- `nullsLast()`: 메시지가 없는 채팅방은 마지막에 표시
- `chatRoom.createdAt.desc()`: 메시지가 없는 경우, 채팅방 생성 시간을 기준으로 내림차순 정렬

## Precaution

## ✔️ Please check if the PR fulfills these requirements

- [ ] It's submitted to the correct branch, not the `develop` branch unconditionally?
- [ ] If on a hotfix branch, ensure it targets `main`?
- [ ] There are no warning message when you run `yarn lint`

- Close #106 