### PR TITLE
[FIX] 현재가 조회에 API 호출 시간 추가

### DIFF
--- a/omocha-client/src/main/java/org/auction/client/bid/application/BidService.java
+++ b/omocha-client/src/main/java/org/auction/client/bid/application/BidService.java
@@ -196,6 +196,6 @@ public class BidService {
 	public NowPriceResponse findNowPrice(Long auctionId) {
 		return findHighestBid(auctionId)
 			.map(NowPriceResponse::toDto)
-			.orElseGet(() -> new NowPriceResponse(0L, null));
+			.orElseGet(() -> new NowPriceResponse(0L, null, LocalDateTime.now()));
 	}
 }

--- a/omocha-client/src/main/java/org/auction/client/bid/interfaces/response/NowPriceResponse.java
+++ b/omocha-client/src/main/java/org/auction/client/bid/interfaces/response/NowPriceResponse.java
@@ -9,14 +9,17 @@ import com.fasterxml.jackson.annotation.JsonFormat;
 public record NowPriceResponse(
 	Long nowPrice,
 	@JsonFormat(pattern = "yyyy-MM-dd HH:mm:ss")
-	LocalDateTime createdAt
+	LocalDateTime createdAt,
+	@JsonFormat(pattern = "yyyy-MM-dd HH:mm:ss")
+	LocalDateTime calledAt
 ) {
 	public static NowPriceResponse toDto(
 		BidEntity bidEntity
 	) {
 		return new NowPriceResponse(
 			bidEntity.getBidPrice(),
-			bidEntity.getCreatedAt()
+			bidEntity.getCreatedAt(),
+			LocalDateTime.now()
 		);
 	}
 }

--- a/omocha-client/src/main/java/org/auction/client/config/security/SecurityConfig.java
+++ b/omocha-client/src/main/java/org/auction/client/config/security/SecurityConfig.java
@@ -57,6 +57,7 @@ public class SecurityConfig {
 			.authorizeHttpRequests(authorize -> authorize
 				.requestMatchers(PERMITTED_ALL_URI).permitAll()
 				.requestMatchers(HttpMethod.GET, "/api/v1/auction/**").permitAll()
+				.requestMatchers(HttpMethod.GET, "/api/v1/bid/**").permitAll()
 				.requestMatchers(HttpMethod.GET, "/api/v1/question/**").permitAll()
 				.anyRequest().authenticated())
 


### PR DESCRIPTION
## What is this PR? 🔍

- 기능 : 현재가 조회에 API 호출 시간 추가
- issue : #120 

## Changes 📝
- 현재가 조회에 API 호출 시간 추가
- SecurityConfig에 bid 관련 GET 요청 permitAll 처리

## Precaution

## ✔️ Please check if the PR fulfills these requirements

- [ ] It's submitted to the correct branch, not the `develop` branch unconditionally?
- [ ] If on a hotfix branch, ensure it targets `main`?
- [ ] There are no warning message when you run `yarn lint`

- Close #120 
